### PR TITLE
docs: Capture Hermes Chat rebrand plan and backlog

### DIFF
--- a/backlog/01_epics.hermes-chat.yaml
+++ b/backlog/01_epics.hermes-chat.yaml
@@ -1,1 +1,162 @@
-<contents from answer above for epics>
+# Hermes Chat rebranding epics capturing enterprise launch scope. Derived from docs/BRANDING.md stakeholder notes.
+epics:
+  - id: EPIC-HC-001
+    name: Hermes Chat Experience & Visual Identity Refresh
+    description: >-
+      Update shared UI theming, marketing assets, and design tokens so every customer-facing
+      touchpoint reflects the Hermes Chat visual system while maintaining accessibility and
+      localization readiness across web and desktop surfaces.
+    business_rationale: >-
+      A unified brand reduces buyer confusion during the LobeChat → Hermes Chat transition and
+      supports the enterprise positioning commitments captured in docs/BRANDING.md.
+    dependencies:
+      - EPIC-HC-003 # Infrastructure must route new domains before updated assets ship publicly.
+    # Decision context: aligns with docs/BRANDING.md#positioning--value-proposition visual standards.
+    acceptance_criteria:
+      - >-
+        100% of shared design tokens in `packages/const/theme.ts` and `apps/web/styles` reference
+        Hermes Chat naming and pass automated contrast checks via CI linting.
+      - >-
+        Updated hero assets and logos exported to `public/brand/hermes-chat/` with Alt text coverage
+        validated by automated accessibility tests.
+      - >-
+        Marketing landing pages deploy with new branding without increasing CLS/LCP by more than 5%
+        compared to pre-refresh baseline (tracked in Vercel analytics dashboard).
+    # Ensures automation-first validation per stakeholder request in docs/BRANDING.md dependencies table.
+    testing_expectations:
+      - >-
+        Extend visual regression coverage in `tests/visual/brand.spec.ts` to snapshot new themes in
+        light/dark modes with Percy or Chromatic automation.
+      - >-
+        Run `bunx vitest run --silent='passed-only' 'tests/unit/theme*'` to ensure design tokens remain
+        backwards compatible.
+    # Automation guardrail: reduces manual asset handling per enterprise readiness goals.
+    automation_expectations:
+      - >-
+        Update `scripts/rebrand_hermes_chat.sh` to regenerate asset exports and purge CDN caches without
+        manual uploads.
+    # Documentation updates anchor visual change log entries for future audits.
+    documentation_expectations:
+      - >-
+        Refresh `docs/BRANDING.md` and marketing wiki entries with before/after visuals and accessibility
+        notes linked from the release announcement.
+
+  - id: EPIC-HC-002
+    name: Core Product Copy, Localization, and Configuration Rebrand
+    description: >-
+      Replace legacy LobeChat naming across application strings, configuration constants, and
+      automation scripts to reflect Hermes Chat while preserving translation quality and developer
+      ergonomics.
+    business_rationale: >-
+      Ensures enterprise admins experience a consistent identity throughout workflows, minimizing
+      support tickets tied to naming mismatches noted in docs/BRANDING.md success metrics.
+    dependencies:
+      - EPIC-HC-001 # Visual tokens define the canonical naming and tagline references.
+    # Decision context: supports localization parity goals noted in docs/BRANDING.md#launch-constraints--guardrails.
+    acceptance_criteria:
+      - >-
+        0 deprecated "LobeChat" references remain in `packages/const/` and `src/` string tables as
+        validated by `rg -n "LobeChat"` CI gate.
+      - >-
+        English and zh-CN locale files in `locales/` updated with Hermes Chat messaging, with translation
+        memory diffs reviewed by localization QA.
+      - >-
+        App configuration metadata (OAuth client names, webhook payload brand keys) reflect Hermes Chat
+        and pass integration smoke tests with top 5 enterprise connectors.
+    # Testing prioritizes multilingual regression risk tied to enterprise compliance messaging.
+    testing_expectations:
+      - >-
+        Add regression suites in `tests/e2e/rebrand.spec.ts` covering authentication flows, admin console
+        branding, and webhook payload validation.
+      - >-
+        Execute localization snapshot tests using `bunx vitest run --silent='passed-only' 'tests/i18n/*'`.
+    # Automation to enforce branding consistency and minimize manual lint sweeps.
+    automation_expectations:
+      - >-
+        Extend `scripts/rebrand_hermes_chat.sh` to lint for prohibited terms and auto-open PRs when new
+        strings appear without Hermes Chat branding.
+    # Documentation refresh aligns success enablement content with Hermes Chat references.
+    documentation_expectations:
+      - >-
+        Update `docs/usage/enterprise-guide.md` and API references describing authentication, ensuring
+        screenshots/taglines align with Hermes Chat naming.
+
+  - id: EPIC-HC-003
+    name: Domain Cutover & Deployment Automation
+    description: >-
+      Configure DNS, certificates, environment variables, and deployment pipelines to serve Hermes Chat
+      across primary (`hermes.chat`) and secondary (`app.hermes.chat`, `status.hermes.chat`) domains with
+      zero downtime and auditable rollback paths.
+    business_rationale: >-
+      Aligns infrastructure with the stakeholder-approved domain strategy, enabling marketing launch
+      campaigns and compliance-ready audit logs documented in docs/BRANDING.md.
+    dependencies:
+      - EPIC-HC-001 # Visual assets depend on correct domain paths for CDN purges.
+      - EPIC-HC-002 # Configuration updates must land before DNS cutover to avoid broken callbacks.
+    # Decision context: derived from docs/BRANDING.md#naming--domain-strategy domain commitments.
+    acceptance_criteria:
+      - >-
+        Automated Terraform or Pulumi stack updates provision certificates and DNS records with staged
+        validation for all Hermes Chat domains and document outputs in `infrastructure/` runbooks.
+      - >-
+        Blue/green deployment for `apps/web` validates redirect rules from `chat.lobehub.com` achieving
+        99.99% uptime during the cutover window.
+      - >-
+        Observability dashboards (Grafana + Statuspage) reflect new domains within 24 hours of deployment.
+    # Testing focus: resiliency + latency budgets promised in stakeholder workshop.
+    testing_expectations:
+      - >-
+        Implement synthetic monitoring scripts in `tests/synthetic/domains.spec.ts` verifying redirects,
+        certificate health, and latency budgets (<200ms p95 global).
+      - >-
+        Run disaster-recovery drills documented in `docs/self-hosting/failover.md` to confirm rollback steps.
+    # Automation ensures reproducible infrastructure changes with dual approvals.
+    automation_expectations:
+      - >-
+        Integrate cutover workflows into CI/CD (`.github/workflows/rebrand-cutover.yml`) ensuring approvals
+        from SRE and compliance before production apply steps.
+    # Documentation ties back to migration guides promised to existing tenants.
+    documentation_expectations:
+      - >-
+        Publish migration guides in `docs/self-hosting/migration-hermes-chat.md` and update status page SOPs.
+
+  - id: EPIC-HC-004
+    name: Launch Communications, Enablement, and Analytics Instrumentation
+    description: >-
+      Deliver coordinated launch materials, customer education assets, and analytics tracking to monitor
+      Hermes Chat brand adoption across marketing, product, and support channels.
+    business_rationale: >-
+      Supports success metrics defined in docs/BRANDING.md by ensuring stakeholders measure adoption,
+      educate customers, and manage change effectively.
+    dependencies:
+      - EPIC-HC-001
+      - EPIC-HC-002
+      - EPIC-HC-003
+    # Decision context: supports success metrics in docs/BRANDING.md#success-metrics--signals.
+    acceptance_criteria:
+      - >-
+        Launch announcement content published across docs, changelog, and in-app modals with consistent
+        messaging and CTA instrumentation (UTM + event schemas).
+      - >-
+        Customer success playbooks in `docs/usage/` updated with migration scripts and automation recipes,
+        reviewed by support leadership.
+      - >-
+        Analytics dashboards (Amplitude/Looker) track Hermes Chat conversion funnel with baseline KPIs set
+        before GA +14 days.
+    # Testing ensures instrumentation is reliable for executive dashboards.
+    testing_expectations:
+      - >-
+        Validate tracking plans via automated schema tests in `tests/analytics/tracking-plan.spec.ts` to
+        ensure event payloads conform to analytics contract.
+      - >-
+        Run documentation link check automation (`bun run lint:docs`) confirming no dead links post-refresh.
+    # Automation reduces manual launch ops toil and drift.
+    automation_expectations:
+      - >-
+        Update marketing automation workflows (Iterable/Marketo) via API-driven scripts stored in
+        `scripts/automation/` to prevent manual email sequencing.
+    # Documentation callouts preserve institutional memory for go-to-market teams.
+    documentation_expectations:
+      - >-
+        Add Hermes Chat launch runbook to `docs/changelog/2025-hermes-chat-launch.md` and link to training
+        decks for sales, support, and partners.

--- a/backlog/02_stories_and_tasks.hermes-chat.yaml
+++ b/backlog/02_stories_and_tasks.hermes-chat.yaml
@@ -1,1 +1,441 @@
-<contents from answer above for stories and tasks>
+# Stories and tasks derived from Hermes Chat epics. Comments link back to docs/BRANDING.md context.
+stories:
+  - id: STORY-HC-001
+    epic_id: EPIC-HC-001
+    title: Align shared theming tokens with Hermes Chat palette
+    priority: P0
+    description: >-
+      Update shared design tokens and component themes to adopt Hermes Chat naming, palettes,
+      and typography while preserving WCAG AA accessibility budgets across light and dark modes.
+    # Context: Visual identity pillars defined in docs/BRANDING.md#positioning--value-proposition.
+    acceptance_criteria:
+      - >-
+        `packages/const/theme.ts` exports Hermes Chat palette variables, typography scale, and spacing
+        tokens that pass automated contrast audits.
+      - >-
+        `apps/web/styles/global.less` references updated token names without breaking existing imports.
+      - >-
+        Percy/Chromatic snapshots confirm no regressions on the marketing home hero and dashboard shell.
+    testing:
+      - >-
+        Add `tests/visual/brand.spec.ts` coverage for theme switcher permutations and run via CI pipeline.
+      - >-
+        Execute `bunx vitest run --silent='passed-only' 'tests/unit/theme*'` locally before merge.
+    documentation:
+      - >-
+        Document new token naming table in `docs/development/design-system.md` including rationale.
+    tasks:
+      - id: TASK-HC-001A
+        type: engineering
+        owner: design-platform
+        description: >-
+          Refactor `packages/const/theme.ts` to export Hermes-specific palettes, gradients, and font stacks
+          with backwards-compatible aliases for downstream packages.
+        references:
+          - packages/const/theme.ts
+          - apps/web/styles/global.less
+        automation:
+          - Update `scripts/rebrand_hermes_chat.sh` to regenerate CSS variables and purge CDN caches.
+        testing:
+          - Percy baseline refresh + `bunx vitest run --silent='passed-only' 'tests/unit/theme*'`.
+        documentation:
+          - Add changelog entry in `docs/changelog/2025-hermes-chat-launch.md` detailing token updates.
+      - id: TASK-HC-001B
+        type: engineering
+        owner: qa-automation
+        description: >-
+          Extend visual regression harness in `tests/visual/brand.spec.ts` covering hero, dashboard shell,
+          and settings themes with Hermes branding toggles.
+        references:
+          - tests/visual/brand.spec.ts
+          - packages/const/theme.ts
+        automation:
+          - Configure Percy project to block merges on diff threshold >0.2%.
+        testing:
+          - Run updated visual suite via CI and capture baseline artifacts in S3 bucket.
+        documentation:
+          - Update `docs/development/testing/visual-regression.md` with new coverage map.
+
+  - id: STORY-HC-002
+    epic_id: EPIC-HC-001
+    title: Refresh marketing and in-app assets for Hermes Chat visuals
+    priority: P1
+    description: >-
+      Produce Hermes Chat-branded assets, integrate them into marketing and app surfaces, and automate
+      export pipelines to avoid manual uploads.
+    # Context: Asset changeover scheduled post-domain cutover per docs/BRANDING.md#dependencies--action-items.
+    acceptance_criteria:
+      - >-
+        New SVG/PNG assets live in `public/brand/hermes-chat/` with hashed filenames for cache busting.
+      - >-
+        In-app modal illustrations and email templates pull Hermes imagery via centralized CDN paths.
+      - >-
+        Asset export pipeline can be triggered via `scripts/rebrand_hermes_chat.sh assets`.
+    testing:
+      - >-
+        Run automated accessibility lint to confirm Alt text for marketing hero and in-app modals.
+      - >-
+        Execute `bunx vitest run --silent='passed-only' 'tests/unit/emailTemplates*'` to catch asset regressions.
+    documentation:
+      - >-
+        Embed before/after comparisons in `docs/BRANDING.md` and asset source references in `docs/wiki/design/`.
+    tasks:
+      - id: TASK-HC-002A
+        type: design
+        owner: brand-studio
+        description: >-
+          Generate Hermes Chat hero, favicon, and email illustration assets; export to `public/brand/hermes-chat/`
+          using Figma automation plugins.
+        references:
+          - public/brand/
+          - scripts/rebrand_hermes_chat.sh
+        automation:
+          - Extend export CLI to pull from Figma API and upload directly to CDN bucket.
+        testing:
+          - Accessibility audit via axe-core CLI ensuring Alt text metadata.
+        documentation:
+          - Update asset inventory table in `docs/wiki/design/hermes-chat-visual-system.md`.
+      - id: TASK-HC-002B
+        type: engineering
+        owner: growth-eng
+        description: >-
+          Wire Hermes assets into marketing Next.js pages (`apps/web/app/(marketing)`) and transactional email
+          templates in `packages/const/emails.ts` with feature flag for staged rollout.
+        references:
+          - apps/web/app/(marketing)
+          - packages/const/emails.ts
+        automation:
+          - Add asset integrity check to `scripts/rebrand_hermes_chat.sh verify-assets` command.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/unit/emailTemplates*'` and preview marketing pages locally.
+        documentation:
+          - Capture rollout plan in `docs/development/release-checklist.md`.
+
+  - id: STORY-HC-003
+    epic_id: EPIC-HC-002
+    title: Replace product strings and configs with Hermes nomenclature
+    priority: P0
+    description: >-
+      Update server and client configuration values, user-visible copy, and automation webhooks to reference
+      Hermes Chat across the stack with governance guardrails for future regressions.
+    # Context: Minimizes naming confusion tracked in docs/BRANDING.md#success-metrics--signals.
+    acceptance_criteria:
+      - >-
+        `packages/const/app.ts` and `src/config/branding.ts` expose Hermes Chat metadata with fallback aliases removed.
+      - >-
+        OAuth callback descriptors and webhook payloads emit `brand: "hermes-chat"` keys.
+      - >-
+        CI job fails when `rg "LobeChat"` finds strings outside approved archive list.
+    testing:
+      - >-
+        Add `tests/e2e/rebrand.spec.ts` coverage for onboarding, workspace rename, and billing flows.
+      - >-
+        Execute contract tests for webhook payloads using `tests/automation/webhook-contract.spec.ts`.
+    documentation:
+      - >-
+        Update `docs/usage/enterprise-guide.md` and `docs/self-hosting/configuration.md` with new environment variable names.
+    tasks:
+      - id: TASK-HC-003A
+        type: engineering
+        owner: platform-core
+        description: >-
+          Refactor `packages/const/app.ts`, `packages/const/emails.ts`, and `src/config/branding.ts` to centralize Hermes Chat
+          copy, tagline, and support links while removing deprecated exports.
+        references:
+          - packages/const/app.ts
+          - packages/const/emails.ts
+          - src/config/branding.ts
+        automation:
+          - Extend `scripts/rebrand_hermes_chat.sh lint-strings` to check for forbidden tokens.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/unit/config*'`.
+        documentation:
+          - Record API name changes in `docs/changelog/2025-hermes-chat-launch.md`.
+      - id: TASK-HC-003B
+        type: engineering
+        owner: integrations
+        description: >-
+          Update webhook + OAuth fixtures in `tests/automation/` and `apps/web/api/` to emit Hermes identifiers and validate
+          via staging connectors.
+        references:
+          - tests/automation/webhook-contract.spec.ts
+          - apps/web/api/
+        automation:
+          - Add smoke validation to CI using staging credentials with masked secrets via GitHub OIDC.
+        testing:
+          - Execute connector smoke tests via `bun run test:connectors --filter hermes`.
+        documentation:
+          - Update integration guides in `docs/usage/integrations/*.md` to reflect new identifiers.
+
+  - id: STORY-HC-004
+    epic_id: EPIC-HC-002
+    title: Localize Hermes Chat copy and enforce translation workflow
+    priority: P1
+    description: >-
+      Refresh localization bundles for Hermes Chat messaging in English and zh-CN, establish automation to flag
+      untranslated strings, and update translation QA scripts.
+    # Context: Launch parity requirement from docs/BRANDING.md#launch-constraints--guardrails.
+    acceptance_criteria:
+      - >-
+        `locales/en-US/*.json` and `locales/zh-CN/*.json` reflect Hermes copy for navigation, emails, and modals.
+      - >-
+        Localization QA sign-off recorded with screenshot diffs in the translation backlog.
+      - >-
+        i18n CI step fails when new strings ship without Hermes translations.
+    testing:
+      - >-
+        Execute `bunx vitest run --silent='passed-only' 'tests/i18n/*'` and review screenshot diffs.
+      - >-
+        Run `bun run lint:i18n` to ensure namespace completeness.
+    documentation:
+      - >-
+        Add translation workflow updates to `docs/development/i18n.md`.
+    tasks:
+      - id: TASK-HC-004A
+        type: localization
+        owner: localization-guild
+        description: >-
+          Update translation files in `locales/en-US/` and `locales/zh-CN/` with Hermes Chat copy, referencing the approved
+          messaging architecture worksheet.
+        references:
+          - locales/en-US/
+          - locales/zh-CN/
+        automation:
+          - Configure Crowdin/GitHub sync to auto-open PRs on new source strings.
+        testing:
+          - `bunx vitest run --silent='passed-only' 'tests/i18n/*'` with locale-specific snapshots.
+        documentation:
+          - Note QA evidence links in `docs/development/i18n.md`.
+      - id: TASK-HC-004B
+        type: engineering
+        owner: tooling
+        description: >-
+          Enhance i18n pipeline to block merges when Hermes translations missing; update `scripts/rebrand_hermes_chat.sh
+          validate-i18n` command to run in CI.
+        references:
+          - scripts/rebrand_hermes_chat.sh
+          - .github/workflows/i18n.yml
+        automation:
+          - Add CI job invoking `scripts/rebrand_hermes_chat.sh validate-i18n` with summary comment on PR.
+        testing:
+          - Dry-run workflow in staging branch to validate gating behavior.
+        documentation:
+          - Update `docs/development/release-checklist.md` with new localization gate.
+
+  - id: STORY-HC-005
+    epic_id: EPIC-HC-003
+    title: Provision Hermes Chat domains with automated infrastructure-as-code
+    priority: P0
+    description: >-
+      Implement infrastructure-as-code updates to manage DNS, TLS certificates, and environment variables for the Hermes Chat
+      domain suite while ensuring auditability and staged rollouts.
+    # Context: Domain strategy defined in docs/BRANDING.md#naming--domain-strategy.
+    acceptance_criteria:
+      - >-
+        Terraform/Pulumi modules in `infrastructure/domains/` declare Hermes hostnames with staged validation and outputs stored
+        in secrets manager.
+      - >-
+        ACME certificate automation validated in staging with automated renewal alerts integrated into PagerDuty.
+      - >-
+        Environment variables in `.env.production` templates reflect Hermes URLs with fallback support for legacy tenants.
+    testing:
+      - >-
+        Run infrastructure unit tests via `pnpm --filter infrastructure test` (or equivalent) and stage apply in sandbox.
+      - >-
+        Execute synthetic monitoring script `tests/synthetic/domains.spec.ts` after staging deploy.
+    documentation:
+      - >-
+        Update `docs/self-hosting/migration-hermes-chat.md` with DNS cutover checklist and rollback procedure.
+    tasks:
+      - id: TASK-HC-005A
+        type: engineering
+        owner: sre
+        description: >-
+          Extend Terraform/Pulumi stacks to include Hermes Chat records, certificate resources, and Traffic Manager routing,
+          using canary weighted distribution.
+        references:
+          - infrastructure/domains/
+          - .github/workflows/rebrand-cutover.yml
+        automation:
+          - Add automated drift detection via Terraform Cloud or Pulumi Deploy with weekly reports.
+        testing:
+          - Sandbox `terraform plan` or `pulumi preview` recorded and attached to PR.
+        documentation:
+          - Document apply/rollback SOP in `docs/self-hosting/migration-hermes-chat.md`.
+      - id: TASK-HC-005B
+        type: engineering
+        owner: sre
+        description: >-
+          Configure GitHub Actions workflow `.github/workflows/rebrand-cutover.yml` to orchestrate staged deploy, approval gates,
+          and synthetic health checks post-deploy.
+        references:
+          - .github/workflows/rebrand-cutover.yml
+          - tests/synthetic/domains.spec.ts
+        automation:
+          - Implement required approvals from SRE + compliance teams with Slack notifications.
+        testing:
+          - Dry-run workflow using staging secrets and verify auto-rollback triggers on failure.
+        documentation:
+          - Update `docs/development/release-checklist.md` with workflow diagram.
+
+  - id: STORY-HC-006
+    epic_id: EPIC-HC-003
+    title: Execute redirect and monitoring rollout for Hermes domains
+    priority: P1
+    description: >-
+      Implement redirect logic, monitoring dashboards, and incident response updates to support Hermes Chat domain cutover
+      without customer downtime.
+    # Context: Redirect promises captured in docs/BRANDING.md#naming--domain-strategy.
+    acceptance_criteria:
+      - >-
+        Redirect map configured in `apps/web/middleware.ts` covering top 200 legacy URLs with analytics tagging.
+      - >-
+        Observability dashboards updated to reflect Hermes domains and error budgets.
+      - >-
+        Statuspage + PagerDuty integrations send Hermes-labeled notifications.
+    testing:
+      - >-
+        Synthetic monitoring assertions for redirect latency (<200ms p95) using `tests/synthetic/domains.spec.ts`.
+      - >-
+        Chaos test verifying rollback toggles via feature flag in `packages/const/featureFlags.ts`.
+    documentation:
+      - >-
+        Update incident response SOP in `docs/self-hosting/failover.md` and `docs/development/oncall-runbook.md`.
+    tasks:
+      - id: TASK-HC-006A
+        type: engineering
+        owner: platform-core
+        description: >-
+          Implement redirect + feature flag logic in `apps/web/middleware.ts` and `packages/const/featureFlags.ts` with telemetry
+          events instrumented for adoption analytics.
+        references:
+          - apps/web/middleware.ts
+          - packages/const/featureFlags.ts
+        automation:
+          - Add redirect coverage check to `scripts/rebrand_hermes_chat.sh verify-redirects`.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/synthetic/domains.spec.ts'` locally pre-merge.
+        documentation:
+          - Document redirect map in `docs/self-hosting/migration-hermes-chat.md` appendix.
+      - id: TASK-HC-006B
+        type: engineering
+        owner: observability
+        description: >-
+          Update Grafana dashboards, Prometheus alerts, and Statuspage automation to reference Hermes domains and uptime SLIs.
+        references:
+          - observability/grafana/
+          - scripts/automation/statuspage-sync.ts
+        automation:
+          - Schedule nightly Statuspage sync via GitHub Actions to avoid manual updates.
+        testing:
+          - Validate dashboards via automated screenshot diff tool in `tests/observability/dashboard.spec.ts`.
+        documentation:
+          - Update monitoring guide in `docs/development/observability.md`.
+
+  - id: STORY-HC-007
+    epic_id: EPIC-HC-004
+    title: Launch communications & enablement package
+    priority: P0
+    description: >-
+      Deliver Hermes Chat announcement materials, in-app education, and success enablement collateral with automated
+      distribution and analytics tracking.
+    # Context: Supports go-to-market enablement plan from docs/BRANDING.md#dependencies--action-items.
+    acceptance_criteria:
+      - >-
+        Announcement posts published to `docs/changelog/2025-hermes-chat-launch.md`, marketing blog, and in-app modal with
+        consistent messaging + UTMs.
+      - >-
+        Customer success toolkit (email templates, FAQ, migration script) stored in `docs/usage/` and surfaced in-app.
+      - >-
+        Iterable/Marketo workflows updated with Hermes segmentation and scheduled automation.
+    testing:
+      - >-
+        Run documentation link checker `bun run lint:docs` to ensure CTA integrity.
+      - >-
+        QA in-app education flows via `tests/e2e/rebrand.spec.ts` gating on CTA events.
+    documentation:
+      - >-
+        Archive enablement assets in `docs/wiki/gtm/hermes-chat-launch.md` with versioning notes.
+    tasks:
+      - id: TASK-HC-007A
+        type: marketing-ops
+        owner: growth-eng
+        description: >-
+          Build and schedule Iterable/Marketo workflows with Hermes segments using API-driven scripts under `scripts/automation/`.
+        references:
+          - scripts/automation/
+          - docs/changelog/2025-hermes-chat-launch.md
+        automation:
+          - Add CI job to lint marketing automation configs before deployment.
+        testing:
+          - Fire test campaigns to sandbox audience verifying event tracking.
+        documentation:
+          - Document workflow IDs + triggers in `docs/wiki/gtm/hermes-chat-launch.md`.
+      - id: TASK-HC-007B
+        type: content
+        owner: product-marketing
+        description: >-
+          Draft announcement blog, changelog entry, FAQ, and in-app copy referencing Hermes positioning.
+        references:
+          - docs/changelog/2025-hermes-chat-launch.md
+          - docs/usage/
+        automation:
+          - Use markdown linter + translation sync via `scripts/rebrand_hermes_chat.sh prepare-content`.
+        testing:
+          - Run `bun run lint:docs` and peer review by legal/compliance.
+        documentation:
+          - Store approval notes in `docs/wiki/gtm/hermes-chat-launch.md`.
+
+  - id: STORY-HC-008
+    epic_id: EPIC-HC-004
+    title: Instrument analytics for Hermes adoption dashboards
+    priority: P1
+    description: >-
+      Implement analytics schema updates, dashboards, and data quality automation to measure Hermes Chat adoption across web,
+      product, and support channels.
+    # Context: Tracks success metrics defined in docs/BRANDING.md#success-metrics--signals.
+    acceptance_criteria:
+      - >-
+        Analytics schema updated in `packages/const/analytics.ts` with Hermes events, documented in tracking plan.
+      - >-
+        Amplitude/Looker dashboards published with baseline metrics captured GA +14 days.
+      - >-
+        Data quality monitors alert on missing events within 1 hour.
+    testing:
+      - >-
+        Add schema tests in `tests/analytics/tracking-plan.spec.ts` verifying payload shapes.
+      - >-
+        Run data backfill dry-run verifying no duplicate events.
+    documentation:
+      - >-
+        Update tracking plan in `docs/development/analytics.md` and share in stakeholder channel.
+    tasks:
+      - id: TASK-HC-008A
+        type: data-engineering
+        owner: data-platform
+        description: >-
+          Update event schemas in `packages/const/analytics.ts`, adjust ingestion pipeline configs, and backfill historical data
+          with Hermes identifiers.
+        references:
+          - packages/const/analytics.ts
+          - analytics/pipeline/
+        automation:
+          - Add schema validation step to CI via `bunx vitest run --silent='passed-only' 'tests/analytics/*'`.
+        testing:
+          - Execute backfill dry-run in staging warehouse and validate row counts.
+        documentation:
+          - Document pipeline changes in `docs/development/analytics.md`.
+      - id: TASK-HC-008B
+        type: data-analytics
+        owner: biz-ops
+        description: >-
+          Build Looker dashboard + Amplitude boards for Hermes adoption metrics and integrate alerts with Slack + PagerDuty.
+        references:
+          - analytics/dashboards/
+          - docs/development/analytics.md
+        automation:
+          - Schedule nightly refresh jobs via dbt Cloud or Looker scheduler.
+        testing:
+          - Validate dashboards using screenshot diffs stored under `tests/analytics/dashboard-visual.spec.ts`.
+        documentation:
+          - Capture metric definitions + owners in `docs/development/analytics.md` appendix.

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -1,1 +1,52 @@
-<contents from answer above for branding>
+# Hermes Chat Brand Alignment Notes
+
+_Last updated: 2024-11-24_
+
+## Stakeholder Coordination Summary
+- **Session date**: 2024-11-22 (virtual workshop + async follow-up)
+- **Facilitator**: Brand PM (Avery Chen) with product leadership (Diego Ramirez) and GTM lead (Priya Natarajan)
+- **Key takeaways**:
+  - Unified on **Hermes Chat** as the customer-facing name and "Hermes" as the internal program codename.
+  - Confirmed go-to-market focus on enterprise security, multilingual copilot workflows, and developer extensibility.
+  - Established a dual-domain strategy (`hermes.chat` primary, `app.hermes.chat` for hosted console) with redirect playbook for legacy links.
+
+## Positioning & Value Proposition
+- **Positioning statement**: "Hermes Chat is the enterprise-grade conversational AI workspace that lets regulated teams reason over knowledge safely, automate decisions, and deploy multilingual copilots without infrastructure overhead."
+- **Target segments**: Financial services compliance teams, enterprise knowledge ops, and platform engineering teams tasked with AI adoption.
+- **Differentiators**:
+  1. Zero-retention, region-aware data residency with auditable policy enforcement.
+  2. Extensible automation surface (webhooks, workflow SDKs) that ships with opinionated governance guardrails.
+  3. Multilingual experience with human-in-the-loop escalation.
+- **Supporting narrative pillars**: Trust & compliance, operational velocity, and global enablement.
+
+## Naming & Domain Strategy
+- **Primary product name**: Hermes Chat (customer facing). Internal initiative: Project Hermes.
+- **Tagline**: "Enterprise conversations, governed intelligence."
+- **Domain ownership**:
+  - `hermes.chat`: Marketing site + docs (`docs.hermes.chat`).
+  - `app.hermes.chat`: Managed SaaS console with SSO enforced.
+  - `status.hermes.chat`: Statuspage-managed uptime communications.
+- **Redirect plan**: Maintain 12-month redirects from `chat.lobehub.com` to mapped destinations with analytics tagging for migration reporting.
+- **Trademark review**: Legal submitted filings in US/EU (docket LOB-2024-118) with monthly checkpoints.
+
+## Launch Constraints & Guardrails
+- **Target beta window**: 2025-01-15 soft launch to design partners, GA on 2025-03-15 pending compliance sign-off.
+- **Security gates**: SOC 2 Type II evidence updates and ISO 27001 control alignment required prior to GA.
+- **Localization**: Minimum EN + zh-CN parity at launch; FR/DE queued post-GA.
+- **Change management**: Migration guides must reach existing LobeChat Pro tenants 30 days before domain cutover.
+
+## Success Metrics & Signals
+- 95%+ successful SSO migration rate within first 14 days of beta.
+- 20% lift in enterprise pipeline influenced by brand refresh in Q1 FY25.
+- Sub-2% brand support tickets referencing naming confusion after GA (measured via Zendesk tag `brand-hermes`).
+
+## Dependencies & Action Items
+- **Design**: Finalize iconography + typography kit (`docs/wiki/design/hermes-chat-visual-system.fig` export) by 2024-12-05.
+- **Product**: Update roadmap artifacts and release notes to reference Hermes Chat naming by sprint HC-2024.48.
+- **Marketing**: Launch teaser landing page variant tests by 2024-12-10; coordinate with paid media for new keyword sets.
+- **Engineering**: Execute rebrand automation scripts, update translations, and refresh docs per epics backlog.
+
+## Reference Materials
+- [Stakeholder briefing deck](https://drive.example.com/hermes-chat-brand-brief) (internal access).
+- [Messaging architecture worksheet](https://miro.example.com/hermes-chat-positioning) (internal access).
+- Internal backlog alignment: see `backlog/01_epics.hermes-chat.yaml` and `backlog/02_stories_and_tasks.hermes-chat.yaml` for implementation scope.


### PR DESCRIPTION
## Summary
- document stakeholder-aligned Hermes Chat positioning, naming, domain, and launch guardrails in the shared branding notes
- author four enterprise-focused Hermes Chat rebrand epics with measurable acceptance, testing, automation, and documentation expectations
- break epics into prioritized user stories and tasks that reference specific modules, automation hooks, and documentation touchpoints

## Testing
- not run (planning and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e14fb56e80832e8391316af70c5c70