### PR TITLE
Extend Hermes rebranding replacements to kebab and snake case tokens

### DIFF
--- a/docs/development/rebranding.md
+++ b/docs/development/rebranding.md
@@ -21,6 +21,9 @@ roll back rebrands without manually touching thousands of strings.
 - Hermes Chat brand constants now live in `packages/const/src/branding.ts` and
   `packages/const/src/url.ts`. Any automation consuming historical Hermes Chat
   values must migrate to the Hermes equivalents before release promotion.
+- The rebranding CLI now rewrites **kebab-case** (`lobe-chat` / `LOBE-CHAT`) and
+  **snake_case** (`lobe_chat` / `LOBE_CHAT`) permutations so Docker services,
+  Helm releases, and environment constants migrate without manual follow-up.
 
 ## Usage
 

--- a/scripts/rebrandHermesChat.ts
+++ b/scripts/rebrandHermesChat.ts
@@ -123,10 +123,34 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     replacement: (brand) => brand.name.toLowerCase().replaceAll(/\s+/g, '-'),
   },
   {
+    description: 'Kebab-case service identifiers such as docker-compose service names (lobe-chat).',
+    id: 'product-name-kebab',
+    pattern: /\blobe-chat\b/g,
+    replacement: (brand) => brand.shortName.toLowerCase().replaceAll(/\s+/g, '-'),
+  },
+  {
     description: 'Uppercase tokens such as environment variables or constants.',
     id: 'product-name-uppercase',
     pattern: /\bLOBECHAT\b/g,
     replacement: (brand) => brand.name.toUpperCase().replaceAll(/\s+/g, '_'),
+  },
+  {
+    description: 'Uppercase kebab-case constants (e.g., Helm release names LOBE-CHAT).',
+    id: 'product-name-uppercase-kebab',
+    pattern: /\bLOBE-CHAT\b/g,
+    replacement: (brand) => brand.shortName.toUpperCase().replaceAll(/\s+/g, '-'),
+  },
+  {
+    description: 'Snake_case identifiers such as database schemas (lobe_chat).',
+    id: 'product-name-snake',
+    pattern: /\blobe_chat\b/g,
+    replacement: (brand) => brand.shortName.toLowerCase().replaceAll(/\s+/g, '_'),
+  },
+  {
+    description: 'Upper snake case identifiers used in environment variables (LOBE_CHAT).',
+    id: 'product-name-uppercase-snake',
+    pattern: /\bLOBE_CHAT\b/g,
+    replacement: (brand) => brand.shortName.toUpperCase().replaceAll(/\s+/g, '_'),
   },
   {
     description:
@@ -244,7 +268,8 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     description: 'Environment variables referencing lobehub cloud.',
     id: 'service-mode-flag',
     pattern: /lobehubCloud/g,
-    replacement: (brand) => `${(brand.organization?.name ?? brand.name).replaceAll(/\s+/g, '')}Cloud`,
+    replacement: (brand) =>
+      `${(brand.organization?.name ?? brand.name).replaceAll(/\s+/g, '')}Cloud`,
   },
 ];
 
@@ -381,7 +406,7 @@ async function applyReplacements(
   brand: BrandMetadata,
   rules: readonly ReplacementRule[],
   dryRun: boolean,
-): Promise<{ counts: Record<string, number>, modified: boolean; }> {
+): Promise<{ counts: Record<string, number>; modified: boolean }> {
   const raw = await readFile(filePath);
 
   if (detectBinary(raw)) {
@@ -562,7 +587,9 @@ function parseBrandOverridesFromArgs(): {
     const ownerFallback =
       repositoryOverrides.owner ??
       baseRepository?.owner ??
-      (metadataBrand.organization?.name ?? metadataBrand.name).toLowerCase().replaceAll(/\s+/g, '-');
+      (metadataBrand.organization?.name ?? metadataBrand.name)
+        .toLowerCase()
+        .replaceAll(/\s+/g, '-');
     const nameFallback =
       repositoryOverrides.name ??
       baseRepository?.name ??

--- a/tests/scripts/rebrandHermesChat.test.ts
+++ b/tests/scripts/rebrandHermesChat.test.ts
@@ -88,7 +88,7 @@ async function createWorkspace(): Promise<string> {
 
   await writeFile(
     join(workspace, 'docs.md'),
-    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nSocial: Follow us @lobehub!\nAsset: /assets/logo/lobehub.svg\n`,
+    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nSocial: Follow us @lobehub!\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nMarkdown sample: \`lobe_chat\`\n`,
     'utf8',
   );
 
@@ -144,6 +144,10 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).toContain('@hermeslabs!');
       expect(docs).toContain('/brand/logo.svg');
       expect(docs).toContain('urn:hermeslabs:chat');
+      expect(docs).toContain('Docker service: hermes-qa');
+      expect(docs).toContain('Helm release: HERMES-QA');
+      expect(docs).toContain('Environment constant: HERMES_QA');
+      expect(docs).toContain('`hermes_qa`');
       expect(docs).not.toContain('LobeChat');
       expect(docs).not.toContain('lobehub.com');
 


### PR DESCRIPTION
## Summary
- expand the rebranding rule catalog to rewrite lobe-chat and lobe_chat variants using the configured short name
- seed the CLI test workspace with kebab/snake case fixtures and assert the migrated Hermes replacements
- document the broader token coverage in the rebranding guide for operators

## Testing
- bunx vitest run --silent='passed-only' 'tests/scripts/rebrandHermesChat.test.ts'

------
https://chatgpt.com/codex/tasks/task_e_68e172144ff4832eb3b2b327605314de