### PR TITLE
Expand Hermes rebrand coverage for Lobechat legacy URLs

### DIFF
--- a/docs/development/rebranding.md
+++ b/docs/development/rebranding.md
@@ -24,6 +24,13 @@ roll back rebrands without manually touching thousands of strings.
 - The rebranding CLI now rewrites **kebab-case** (`lobe-chat` / `LOBE-CHAT`) and
   **snake_case** (`lobe_chat` / `LOBE_CHAT`) permutations so Docker services,
   Helm releases, and environment constants migrate without manual follow-up.
+- Domain automation now also covers legacy `lobechat.com` (including
+  `www.lobechat.com`) addresses so vanity links route through the new Hermes
+  entrypoints without post-run edits.
+- Raw asset download URLs rooted at
+  `https://raw.githubusercontent.com/lobehub/lobe-chat` are rewritten to the
+  Hermes CDN (falling back to the primary domain when no CDN is configured),
+  preserving the branch/path suffix for deterministic migrations.
 
 ## Usage
 

--- a/scripts/rebrandHermesChat.ts
+++ b/scripts/rebrandHermesChat.ts
@@ -198,9 +198,23 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     replacement: (brand) => brand.domain,
   },
   {
+    description:
+      'Legacy lobechat.com hostnames (without www) that still surface in historical READMEs and deployment manifests.',
+    id: 'legacy-lobechat-domain',
+    pattern: /lobechat\.com/g,
+    replacement: (brand) => brand.domain,
+  },
+  {
     description: 'www-prefixed marketing domains.',
     id: 'www-domain',
     pattern: /www\.lobehub\.com/g,
+    replacement: (brand) => `www.${brand.domain}`,
+  },
+  {
+    description:
+      'www-prefixed lobechat.com hostnames to guarantee vanity links follow the new Hermes entrypoint.',
+    id: 'legacy-lobechat-domain-www',
+    pattern: /www\.lobechat\.com/g,
     replacement: (brand) => `www.${brand.domain}`,
   },
   {
@@ -208,6 +222,23 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     id: 'cdn-domain',
     pattern: /cdn\.lobehub\.com/g,
     replacement: (brand) => brand.cdnDomain ?? brand.domain,
+  },
+  {
+    description:
+      'Raw GitHub asset downloads sourced from lobehub/lobe-chat now stream from the Hermes CDN (or domain fallback).',
+    id: 'raw-github-cdn',
+    pattern: /https?:\/\/raw\.githubusercontent\.com\/lobehub\/lobe-chat/g,
+    replacement: (brand) => {
+      const owner =
+        brand.repository?.owner ??
+        brand.organization?.name?.toLowerCase().replaceAll(/\s+/g, '-') ??
+        brand.name.toLowerCase().replaceAll(/\s+/g, '-');
+      const repo =
+        brand.repository?.name ?? brand.name.toLowerCase().replaceAll(/\s+/g, '-');
+      const cdn = brand.cdnDomain ?? brand.domain;
+
+      return `https://${cdn}/${owner}/${repo}`;
+    },
   },
   {
     description: 'Direct logo asset references inside markdown/docs.',

--- a/tests/scripts/rebrandHermesChat.test.ts
+++ b/tests/scripts/rebrandHermesChat.test.ts
@@ -88,7 +88,7 @@ async function createWorkspace(): Promise<string> {
 
   await writeFile(
     join(workspace, 'docs.md'),
-    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nSocial: Follow us @lobehub!\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nMarkdown sample: \`lobe_chat\`\n`,
+    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nLegacy domains: https://lobechat.com + https://www.lobechat.com\nRaw asset: https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/logo.svg\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nSocial: Follow us @lobehub!\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nMarkdown sample: \`lobe_chat\`\n`,
     'utf8',
   );
 
@@ -113,8 +113,9 @@ async function createWorkspace(): Promise<string> {
     join(workspace, 'locale/en.json'),
     JSON.stringify(
       {
-        description: 'Visit https://www.lobehub.com',
+        description: 'Visit https://www.lobehub.com or https://www.lobechat.com',
         slug: 'lobehubCloud',
+        rawCdn: 'https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/icon.png',
       },
       null,
       2,
@@ -139,6 +140,8 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).toContain('Hermes Labs');
       expect(docs).toContain('https://qa.hermes.chat/support');
       expect(docs).toContain('cdn.qa.hermes.chat');
+      expect(docs).toContain('https://qa.hermes.chat + https://www.qa.hermes.chat');
+      expect(docs).toContain('https://cdn.qa.hermes.chat/hermes-chat/chat-enterprise/main/assets/logo.svg');
       expect(docs).toContain('help@hermes.chat');
       expect(docs).toContain('@hermeslabs/ui');
       expect(docs).toContain('@hermeslabs!');
@@ -150,6 +153,8 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).toContain('`hermes_qa`');
       expect(docs).not.toContain('LobeChat');
       expect(docs).not.toContain('lobehub.com');
+      expect(docs).not.toContain('lobechat.com');
+      expect(docs).not.toContain('raw.githubusercontent.com/lobehub/lobe-chat');
 
       const config = await readFile(join(workspace, 'config.json'), 'utf8');
       expect(config).toContain('qa.hermes.chat');
@@ -159,6 +164,7 @@ describe('rebrandHermesChat CLI', () => {
       const locale = await readFile(join(workspace, 'locale/en.json'), 'utf8');
       expect(locale).toContain('https://www.qa.hermes.chat');
       expect(locale).toContain('HermesLabsCloud');
+      expect(locale).toContain('https://cdn.qa.hermes.chat/hermes-chat/chat-enterprise/main/assets/icon.png');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add rebranding rules that normalize lobechat.com and GitHub raw URLs to Hermes metadata-driven domains
- expand the rebranding CLI test fixture to cover the new URLs and assert the rewritten outputs
- document the additional domain and CDN coverage in the rebranding runbook

## Testing
- bunx vitest run --silent='passed-only' 'tests/scripts/rebrandHermesChat.test.ts' *(fails: missing `vitest` dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e174554e24832e9450a481a6f76fa0