### PR TITLE
Extend rebranding CLI coverage for scoped handles

### DIFF
--- a/docs/development/rebranding.md
+++ b/docs/development/rebranding.md
@@ -31,6 +31,11 @@ roll back rebrands without manually touching thousands of strings.
   `https://raw.githubusercontent.com/lobehub/lobe-chat` are rewritten to the
   Hermes CDN (falling back to the primary domain when no CDN is configured),
   preserving the branch/path suffix for deterministic migrations.
+- The automation now standardizes both scoped package imports (`@lobehub/*` and
+  `@lobechat/*`) and bare social handles. Scoped imports adopt the sanitized
+  organization slug (or fall back to the short product name when no org is
+  supplied) so npm installs remain routable, while bare `@lobechat` mentions map
+  to the product short name for human-readable marketing copy.
 
 ## Usage
 

--- a/tests/scripts/rebrandHermesChat.test.ts
+++ b/tests/scripts/rebrandHermesChat.test.ts
@@ -88,7 +88,7 @@ async function createWorkspace(): Promise<string> {
 
   await writeFile(
     join(workspace, 'docs.md'),
-    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nLegacy domains: https://lobechat.com + https://www.lobechat.com\nRaw asset: https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/logo.svg\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nSocial: Follow us @lobehub!\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nMarkdown sample: \`lobe_chat\`\n`,
+    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nLegacy domains: https://lobechat.com + https://www.lobechat.com\nRaw asset: https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/logo.svg\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @lobehub/ui\nScoped migration: @lobechat/analytics\nSocial: Follow us @lobehub!\nCommunity beta: say hi at @lobechat.\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nMarkdown sample: \`lobe_chat\`\n`,
     'utf8',
   );
 
@@ -144,7 +144,9 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).toContain('https://cdn.qa.hermes.chat/hermes-chat/chat-enterprise/main/assets/logo.svg');
       expect(docs).toContain('help@hermes.chat');
       expect(docs).toContain('@hermeslabs/ui');
+      expect(docs).toContain('@hermeslabs/analytics');
       expect(docs).toContain('@hermeslabs!');
+      expect(docs).toContain('@hermesqa');
       expect(docs).toContain('/brand/logo.svg');
       expect(docs).toContain('urn:hermeslabs:chat');
       expect(docs).toContain('Docker service: hermes-qa');
@@ -154,6 +156,7 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).not.toContain('LobeChat');
       expect(docs).not.toContain('lobehub.com');
       expect(docs).not.toContain('lobechat.com');
+      expect(docs).not.toContain('@lobechat');
       expect(docs).not.toContain('raw.githubusercontent.com/lobehub/lobe-chat');
 
       const config = await readFile(join(workspace, 'config.json'), 'utf8');
@@ -179,6 +182,8 @@ describe('rebrandHermesChat CLI', () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout + result.stderr).toContain('Dry run was enabled');
+      expect(result.stdout + result.stderr).toContain('product-scope-lobechat: 1');
+      expect(result.stdout + result.stderr).toContain('product-handle-lobechat: 1');
 
       const after = await readFile(join(workspace, 'docs.md'), 'utf8');
       expect(after).toBe(before);


### PR DESCRIPTION
## Summary
- add reusable slug sanitization and extend the rebranding CLI to rewrite @lobechat scoped imports and handles with rich documentation
- expand the vitest fixtures to cover @lobechat tokens and assert the dry-run summary reports the new rules
- document the additional automation coverage for scoped packages and social handles

## Testing
- `bunx vitest run --silent='passed-only' 'tests/scripts/rebrandHermesChat.test.ts'` *(fails: missing local vitest dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17a9b466c832eb91dfba10d6fab30