### PR TITLE
refactor: align context engine plugin types with Hermes branding

### DIFF
--- a/docs/usage/enterprise-guide.md
+++ b/docs/usage/enterprise-guide.md
@@ -55,6 +55,25 @@ approvals so pre-production rollouts stay aligned with governance policy.
   The snapshot enforces the Hermes author tuples and stops regressions before
   rollout.
 
+## Plugin tooling automation
+
+- **Type migration:** `packages/context-engine/src/tools/types.ts` now exposes
+  `HermesChatPluginApi` and `HermesChatPluginManifest`. The legacy
+  `LobeChat*` aliases remain exported (and marked deprecated) so downstream
+  SDKs can align with the rename on their own release cadences. The migration is
+  documented inline and tied to the automation guardrails below.
+- **Automation guardrail:** `scripts/rebrandHermesChat.ts` rewrites these type
+  identifiers via the `typescript-plugin-api-interface` and
+  `typescript-plugin-manifest-interface` rules. The CLI test fixture (`tests/scripts/rebrandHermesChat.test.ts`)
+  asserts both replacements so CI fails fast if future edits skip the rename.
+- **Verification:** `packages/context-engine/src/tools/__tests__/types.test.ts`
+  adds `expectTypeOf` assertions to guarantee the Hermes-prefixed interfaces stay
+  structurally compatible with their deprecated aliases. Run
+  `bunx vitest run --silent='passed-only' 'packages/context-engine/src/tools/__tests__/types.test.ts'`
+  before shipping plugin schema changes.
+- **Timeline:** Track removal of the deprecated aliases and downstream adoption
+  milestones in the [enterprise migration notes](/docs/changelog/2025-hermes-chat-launch).
+
 ## Support and escalation flow
 
 Hermes Labs Support, Customer Success, and Trust & Safety jointly ratified the

--- a/packages/context-engine/src/tools/ToolsEngine.ts
+++ b/packages/context-engine/src/tools/ToolsEngine.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 import {
   FunctionCallChecker,
   GenerateToolsParams,
-  LobeChatPluginManifest,
+  HermesChatPluginManifest,
   PluginEnableChecker,
   ToolsEngineOptions,
   ToolsGenerationContext,
@@ -18,7 +18,10 @@ const log = debug('context-engine:tools-engine');
  * Tools Engine - Unified processing of tools array construction and transformation
  */
 export class ToolsEngine {
-  private manifestSchemas: Map<string, LobeChatPluginManifest>;
+  // The map now stores Hermes-prefixed manifest contracts; the compatibility
+  // alias in `types.ts` ensures legacy imports continue to function until the
+  // enterprise migration completes.
+  private manifestSchemas: Map<string, HermesChatPluginManifest>;
   private enableChecker?: PluginEnableChecker;
   private functionCallChecker?: FunctionCallChecker;
   private defaultToolIds: string[];
@@ -156,13 +159,13 @@ export class ToolsEngine {
     provider: string,
     context?: ToolsGenerationContext,
   ): {
-    enabledManifests: LobeChatPluginManifest[];
+    enabledManifests: HermesChatPluginManifest[];
     filteredPlugins: Array<{
       id: string;
       reason: 'not_found' | 'disabled' | 'incompatible';
     }>;
   } {
-    const enabledManifests: LobeChatPluginManifest[] = [];
+    const enabledManifests: HermesChatPluginManifest[] = [];
     const filteredPlugins: Array<{
       id: string;
       reason: 'not_found' | 'disabled' | 'incompatible';
@@ -218,7 +221,7 @@ export class ToolsEngine {
   /**
    * Convert manifests to UniformTool array
    */
-  private convertManifestsToTools(manifests: LobeChatPluginManifest[]): UniformTool[] {
+  private convertManifestsToTools(manifests: HermesChatPluginManifest[]): UniformTool[] {
     log('Converting %d manifests to tools', manifests.length);
 
     // Use simplified conversion logic to avoid external package dependencies
@@ -268,14 +271,14 @@ export class ToolsEngine {
   /**
    * 获取插件的 manifest
    */
-  getPluginManifest(pluginId: string): LobeChatPluginManifest | undefined {
+  getPluginManifest(pluginId: string): HermesChatPluginManifest | undefined {
     return this.manifestSchemas.get(pluginId);
   }
 
   /**
    * 更新插件 manifest schemas（用于动态添加插件）
    */
-  updateManifestSchemas(manifestSchemas: LobeChatPluginManifest[]): void {
+  updateManifestSchemas(manifestSchemas: HermesChatPluginManifest[]): void {
     this.manifestSchemas.clear();
     for (const schema of manifestSchemas) {
       this.manifestSchemas.set(schema.identifier, schema);
@@ -285,7 +288,7 @@ export class ToolsEngine {
   /**
    * 添加单个插件 manifest
    */
-  addPluginManifest(manifest: LobeChatPluginManifest): void {
+  addPluginManifest(manifest: HermesChatPluginManifest): void {
     this.manifestSchemas.set(manifest.identifier, manifest);
   }
 

--- a/packages/context-engine/src/tools/__tests__/ToolsEngine.test.ts
+++ b/packages/context-engine/src/tools/__tests__/ToolsEngine.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { ToolsEngine } from '../ToolsEngine';
-import type { LobeChatPluginManifest } from '../types';
+import type { HermesChatPluginManifest } from '../types';
 
 // Mock manifest schemas for testing
-const mockWebBrowsingManifest: LobeChatPluginManifest = {
+const mockWebBrowsingManifest: HermesChatPluginManifest = {
   api: [
     {
       description: 'Search the web',
@@ -26,7 +26,7 @@ const mockWebBrowsingManifest: LobeChatPluginManifest = {
   type: 'builtin',
 };
 
-const mockDalleManifest: LobeChatPluginManifest = {
+const mockDalleManifest: HermesChatPluginManifest = {
   api: [
     {
       description: 'Generate images',
@@ -284,7 +284,7 @@ describe('ToolsEngine', () => {
 
   describe('ToolsEngine Integration Tests (migrated from enabledSchema)', () => {
     // Mock manifest data similar to the original tool selector tests
-    const mockManifests: LobeChatPluginManifest[] = [
+    const mockManifests: HermesChatPluginManifest[] = [
       {
         identifier: 'plugin-1',
         api: [{ name: 'api-1', description: 'API 1', parameters: {} }],
@@ -641,7 +641,7 @@ describe('ToolsEngine', () => {
    */
   describe('enabledSchema Migration to ToolsEngine', () => {
     // Sample manifest data that mimics the old toolSelectors test data
-    const sampleManifests: LobeChatPluginManifest[] = [
+    const sampleManifests: HermesChatPluginManifest[] = [
       {
         identifier: 'plugin-1',
         api: [{ name: 'api-1', description: 'API 1', parameters: {} }],

--- a/packages/context-engine/src/tools/__tests__/types.test.ts
+++ b/packages/context-engine/src/tools/__tests__/types.test.ts
@@ -1,0 +1,44 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type {
+  HermesChatPluginApi,
+  HermesChatPluginManifest,
+  LobeChatPluginApi,
+  LobeChatPluginManifest,
+} from '../types';
+
+/**
+ * Enterprise readiness check: these assertions guarantee the Hermes-prefixed
+ * interfaces remain structurally identical to their legacy counterparts while
+ * the broader monorepo finishes migrating via automation. This reduces manual
+ * QA lift for teams consuming the context engine types.
+ */
+describe('Hermes Chat plugin type migration', () => {
+  it('retains API shape compatibility between Hermes and legacy aliases', () => {
+    expectTypeOf<HermesChatPluginApi>().toEqualTypeOf<LobeChatPluginApi>();
+  });
+
+  it('retains manifest shape compatibility between Hermes and legacy aliases', () => {
+    expectTypeOf<HermesChatPluginManifest>().toEqualTypeOf<LobeChatPluginManifest>();
+  });
+
+  it('exposes Hermes-prefixed manifest utilities for downstream tooling', () => {
+    const manifest: HermesChatPluginManifest = {
+      api: [
+        {
+          description: 'Checks connectivity with enterprise MCP hosts',
+          name: 'healthCheck',
+          parameters: { type: 'object', properties: {} },
+        },
+      ],
+      identifier: 'enterprise-health-check',
+      meta: { tier: 'enterprise' },
+      systemRole: 'assistant',
+      type: 'standalone',
+    };
+
+    const legacyManifest: LobeChatPluginManifest = manifest;
+
+    expectTypeOf(legacyManifest).toMatchTypeOf<HermesChatPluginManifest>();
+  });
+});

--- a/packages/context-engine/src/tools/__tests__/utils.test.ts
+++ b/packages/context-engine/src/tools/__tests__/utils.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import type { LobeChatPluginManifest } from '../types';
+import type { HermesChatPluginManifest } from '../types';
 import { filterValidManifests, validateManifest } from '../utils';
 
 // Mock manifest schemas
-const mockBuiltinManifest: LobeChatPluginManifest = {
+const mockBuiltinManifest: HermesChatPluginManifest = {
   api: [
     {
       description: 'Built-in tool',

--- a/packages/context-engine/src/tools/types.ts
+++ b/packages/context-engine/src/tools/types.ts
@@ -1,17 +1,54 @@
-export interface LobeChatPluginApi {
+/**
+ * Hermes-prefixed plugin API descriptor used by the context engine.
+ *
+ * @remarks
+ * This interface replaces the legacy {@link LobeChatPluginApi} name as part of the
+ * Hermes Chat enterprise rebrand. We intentionally preserve a deprecated type alias
+ * (see below) so downstream packages can adopt the new name gradually without
+ * blocking release trains. The rebrand automation (`scripts/rebrandHermesChat.ts`)
+ * enforces this rename to prevent future regressions.
+ */
+export interface HermesChatPluginApi {
   description: string;
   name: string;
   parameters: Record<string, any>;
   url?: string;
 }
 
-export interface LobeChatPluginManifest {
-  api: LobeChatPluginApi[];
+/**
+ * Canonical manifest schema for Hermes Chat plugins.
+ *
+ * @remarks
+ * Formerly exported as {@link LobeChatPluginManifest}. The compatibility alias
+ * guarantees that previously compiled bundles continue to type-check until the
+ * next major release. The rename clarifies that this manifest is specific to
+ * Hermes Chat while also unlocking future brand-specific tooling.
+ */
+export interface HermesChatPluginManifest {
+  api: HermesChatPluginApi[];
   identifier: string;
   meta: any;
   systemRole?: string;
   type?: 'default' | 'standalone' | 'markdown' | 'mcp' | 'builtin';
 }
+
+/**
+ * Transitional alias retained for compatibility with existing imports.
+ *
+ * @deprecated Use {@link HermesChatPluginApi} instead. The alias will be
+ * removed after downstream consumers migrate via the rebranding automation.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- intentional alias during migration
+export type LobeChatPluginApi = HermesChatPluginApi;
+
+/**
+ * Transitional alias retained for compatibility with existing imports.
+ *
+ * @deprecated Use {@link HermesChatPluginManifest} instead. The alias will be
+ * removed after downstream consumers migrate via the rebranding automation.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- intentional alias during migration
+export type LobeChatPluginManifest = HermesChatPluginManifest;
 
 /**
  * Tools generation context
@@ -36,7 +73,7 @@ export interface ToolsGenerationContext {
  */
 export type PluginEnableChecker = (params: {
   context?: ToolsGenerationContext;
-  manifest: LobeChatPluginManifest;
+  manifest: HermesChatPluginManifest;
   model: string;
   pluginId: string;
   provider: string;
@@ -79,7 +116,7 @@ export interface ToolsEngineOptions {
   /** Optional tool name generator function */
   generateToolName?: ToolNameGenerator;
   /** Statically injected manifest schemas */
-  manifestSchemas: LobeChatPluginManifest[];
+  manifestSchemas: HermesChatPluginManifest[];
 }
 
 /**

--- a/packages/context-engine/src/tools/utils.ts
+++ b/packages/context-engine/src/tools/utils.ts
@@ -1,4 +1,4 @@
-import { LobeChatPluginManifest } from './types';
+import { HermesChatPluginManifest } from './types';
 
 // Tool naming constants
 const PLUGIN_SCHEMA_SEPARATOR = '____';
@@ -46,7 +46,7 @@ export const generateToolName = (
 /**
  * Validate manifest schema structure
  */
-export function validateManifest(manifest: any): manifest is LobeChatPluginManifest {
+export function validateManifest(manifest: any): manifest is HermesChatPluginManifest {
   return Boolean(
     manifest &&
       typeof manifest === 'object' &&
@@ -61,9 +61,13 @@ export function validateManifest(manifest: any): manifest is LobeChatPluginManif
  */
 export function filterValidManifests(manifestSchemas: any[]): {
   invalid: any[];
-  valid: LobeChatPluginManifest[];
+  valid: HermesChatPluginManifest[];
 } {
-  const valid: LobeChatPluginManifest[] = [];
+  // NOTE: We intentionally migrate to Hermes-prefixed types here to keep the
+  // runtime logic aligned with the new manifest contract. The deprecated alias
+  // in `types.ts` still backstops legacy imports until downstream packages are
+  // auto-migrated by `scripts/rebrandHermesChat.ts`.
+  const valid: HermesChatPluginManifest[] = [];
   const invalid: any[] = [];
 
   for (const manifest of manifestSchemas) {

--- a/scripts/rebrandHermesChat.ts
+++ b/scripts/rebrandHermesChat.ts
@@ -201,6 +201,19 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     replacement: (brand) => deriveCloudServiceTokens(brand).constant,
   },
   {
+    description: 'TypeScript interface rename for plugin manifests consumed by the context engine.',
+    id: 'typescript-plugin-manifest-interface',
+    pattern: /\bLobeChatPluginManifest\b/g,
+    replacement: () => 'HermesChatPluginManifest',
+  },
+  {
+    description:
+      'TypeScript interface rename for plugin API descriptors consumed by the context engine.',
+    id: 'typescript-plugin-api-interface',
+    pattern: /\bLobeChatPluginApi\b/g,
+    replacement: () => 'HermesChatPluginApi',
+  },
+  {
     description: 'Marketing copy describing the managed cloud offer in title case.',
     id: 'cloud-token-title',
     pattern: /\bLobe Chat Cloud\b/g,

--- a/tests/scripts/rebrandHermesChat.test.ts
+++ b/tests/scripts/rebrandHermesChat.test.ts
@@ -147,6 +147,12 @@ async function createWorkspace(): Promise<string> {
     'utf8',
   );
 
+  await writeFile(
+    join(workspace, 'types.ts'),
+    `import type { LobeChatPluginApi, LobeChatPluginManifest } from './types';\n\nexport type FixtureManifest = LobeChatPluginManifest & { brand: string };\n\nexport const fixtureApi: LobeChatPluginApi = {\n  description: 'Legacy manifest compatibility smoke test',\n  name: 'legacyTest',\n  parameters: {},\n};\n`,
+    'utf8',
+  );
+
   return workspace;
 }
 
@@ -199,6 +205,12 @@ describe('rebrandHermesChat CLI', () => {
       expect(config).toContain('qa.hermes.chat');
       expect(config).toContain('/brand/favicon.svg');
       expect(config).not.toContain('lobehub');
+
+      const typesFixture = await readFile(join(workspace, 'types.ts'), 'utf8');
+      expect(typesFixture).toContain('HermesChatPluginManifest');
+      expect(typesFixture).toContain('HermesChatPluginApi');
+      expect(typesFixture).not.toContain('LobeChatPluginManifest');
+      expect(typesFixture).not.toContain('LobeChatPluginApi');
 
       const locale = await readFile(join(workspace, 'locale/en.json'), 'utf8');
       expect(locale).toContain('https://www.qa.hermes.chat');


### PR DESCRIPTION
## Summary
- rename the context engine plugin API and manifest interfaces to their Hermes-prefixed counterparts while documenting compatibility aliases
- propagate the new type names through helpers/tests and add a dedicated type assertion suite to guard the migration
- teach the rebranding script and enterprise guide about the automated TypeScript rewrite, expanding fixtures to verify the new rules

## Testing
- cd packages/context-engine && bunx vitest run --silent='passed-only' 'src/tools/__tests__/types.test.ts'
- bunx vitest run --silent='passed-only' 'tests/scripts/rebrandHermesChat.test.ts'


------
https://chatgpt.com/codex/tasks/task_e_68e2950c790c832eb85deffada80c943