### PR TITLE
✨ feat: unify Hermes referral tracking

### DIFF
--- a/docs/development/basic/test.mdx
+++ b/docs/development/basic/test.mdx
@@ -74,6 +74,24 @@ This will run all unit tests and output the test results.
 >   validates SEO metadata snapshots.
 > - `bunx vitest run --silent=passed-only src/app/discover/__tests__/discoverProviderBrand.test.tsx`
 >   confirms the Hermes Cloud provider slug and fallbacks resolve correctly.
+> - `bunx vitest run --silent='passed-only' 'src/config/modelProviders/__tests__/referralLinks.test.ts'`
+>   validates the Growth-approved Hermes referral URLs for partner cards.
+
+## Referral instrumentation guardrails
+
+- Centralise partner and provider referral updates through
+  `src/config/modelProviders/utils/referral.ts`. The helper injects the
+  Growth-sanctioned `utm_source=hermes-chat`, `utm_medium=app_referral`, and
+  `utm_campaign=model_provider` tuple, plus a slug-specific `utm_content` so we
+  never regress dashboards when onboarding new providers.
+- When legacy `lobehub` links pop up in docs or configs, run
+  `bunx tsx scripts/rebrandHermesChat.ts --mode validate --workspace .` to
+  regenerate shortlinks and review the per-rule replacement audit. The CLI now
+  counts each `utm-source-*` replacement so Growth can self-serve compliance
+  checks.
+- Keep the regression test above green before merging provider changes. Extend
+  the assertions whenever new providers start using Hermes shortlinks so CI
+  blocks outdated tracking parameters automatically.
 
 ## Testing Strategy
 

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -20,6 +20,24 @@ when preparing production or enterprise sandboxes.
   transitional alias `LOBE_CHAT_CLOUD` remains available only until OPS-1120
   closes (2025-09-30) to give extensions and custom shells time to upgrade.
 
+## Referral tracking
+
+- **Provider cards:** Shortlink every partner referral through
+  `https://go.hermes.chat/r/<slug>` with Growth's approved UTMs
+  (`utm_source=hermes-chat`, `utm_medium=app_referral`,
+  `utm_campaign=model_provider`, `utm_content=<slug>`). Centralise new links in
+  `src/config/modelProviders/utils/referral.ts` to keep the taxonomy uniform.
+- **Automation:** Run
+  `bunx tsx scripts/rebrandHermesChat.ts --mode validate --workspace .` after
+  touching marketing links. The CLI now logs replacement counts for the
+  `utm-source-*` rules so the Growth pod can audit migrations without manual
+  diffs.
+- **Verification:** Execute
+  `bunx vitest run --silent='passed-only' 'src/config/modelProviders/__tests__/referralLinks.test.ts'`
+  to confirm provider configs emit Hermes shortlinks (invite codes included).
+  Self-hosters inheriting custom forks should gate release pipelines on this
+  suite to avoid reintroducing lobehub parameters.
+
 ## Locale management
 
 Hermes Chat now writes the locale cookie under `HERMES_LOCALE`. For backwards

--- a/scripts/rebrandHermesChat.ts
+++ b/scripts/rebrandHermesChat.ts
@@ -345,6 +345,30 @@ const REBRANDING_RULES: readonly ReplacementRule[] = [
     replacement: (brand) => brand.domain,
   },
   {
+    description: 'Legacy referral source parameters migrate to the Hermes tracking taxonomy.',
+    id: 'utm-source-lobehub',
+    pattern: /utm_source=lobehub/g,
+    replacement: () => 'utm_source=hermes-chat',
+  },
+  {
+    description: 'GitHub specific referral sources collapse into the standard Hermes campaign.',
+    id: 'utm-source-github-lobechat',
+    pattern: /utm_source=github_lobe-?chat/g,
+    replacement: () => 'utm_source=hermes-chat',
+  },
+  {
+    description: 'Legacy README medium tags adopt the Hermes in-product taxonomy.',
+    id: 'utm-medium-github-readme',
+    pattern: /utm_medium=github_readme/g,
+    replacement: () => 'utm_medium=app_referral',
+  },
+  {
+    description: 'Legacy generic "link" campaigns move under the provider umbrella.',
+    id: 'utm-campaign-link',
+    pattern: /utm_campaign=link/g,
+    replacement: () => 'utm_campaign=model_provider',
+  },
+  {
     description:
       'Legacy lobechat.com hostnames (without www) that still surface in historical READMEs and deployment manifests.',
     id: 'legacy-lobechat-domain',

--- a/src/config/modelProviders/__tests__/referralLinks.test.ts
+++ b/src/config/modelProviders/__tests__/referralLinks.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import Ai302 from '../ai302';
+import AiHubMix from '../aihubmix';
+import OpenAI from '../openai';
+import PPIO from '../ppio';
+
+const HERMES_REFERRAL_HOST = 'go.hermes.chat';
+
+function assertHermesReferral(url: string, slug: string): URL {
+  const parsed = new URL(url);
+
+  expect(parsed.hostname).toBe(HERMES_REFERRAL_HOST);
+  expect(parsed.pathname.startsWith('/r/')).toBe(true);
+  expect(parsed.searchParams.get('utm_source')).toBe('hermes-chat');
+  expect(parsed.searchParams.get('utm_medium')).toBe('app_referral');
+  expect(parsed.searchParams.get('utm_campaign')).toBe('model_provider');
+  expect(parsed.searchParams.get('utm_content')).toBe(slug);
+
+  return parsed;
+}
+
+describe('model provider referral links', () => {
+  it('emits Hermes shortlinks for OpenAI', () => {
+    const parsed = assertHermesReferral(OpenAI.apiKeyUrl!, 'openai');
+
+    expect(parsed.pathname).toBe('/r/openai-api-keys');
+  });
+
+  it('emits Hermes shortlinks for AiHubMix', () => {
+    const apiKeys = assertHermesReferral(AiHubMix.apiKeyUrl!, 'aihubmix');
+    const landing = assertHermesReferral(AiHubMix.url!, 'aihubmix');
+
+    expect(apiKeys.pathname).toBe('/r/aihubmix-api-keys');
+    expect(landing.pathname).toBe('/r/aihubmix');
+  });
+
+  it('emits Hermes shortlinks for 302.AI', () => {
+    const parsed = assertHermesReferral(Ai302.apiKeyUrl!, 'ai302');
+
+    expect(parsed.pathname).toBe('/r/ai302-api-keys');
+  });
+
+  it('emits Hermes shortlinks for PPIO and preserves invite tracking', () => {
+    const models = assertHermesReferral(PPIO.modelsUrl!, 'ppio');
+    const signup = assertHermesReferral(PPIO.url!, 'ppio');
+
+    expect(models.pathname).toBe('/r/ppio-models');
+    expect(signup.pathname).toBe('/r/ppio-signup');
+    expect(signup.searchParams.get('invited_by')).toBe('RQIMOC');
+  });
+});

--- a/src/config/modelProviders/ai302.ts
+++ b/src/config/modelProviders/ai302.ts
@@ -1,8 +1,19 @@
 import { ModelProviderCard } from '@/types/llm';
 
+import { buildHermesReferralUrl } from './utils/referral';
+
+// NOTE(HERMES-GROWTH-2025-02-18): Retiring the lobe.li short link keeps 302.AI
+// referrals measurable in the Hermes dashboards without relying on third-party
+// link rot. Growth signed off on this slug so we can segment conversions by
+// provider moving forward.
+const AI302_API_KEY_REFERRAL = buildHermesReferralUrl({
+  destination: 'ai302-api-keys',
+  slug: 'ai302',
+});
+
 // ref: https://302.ai/pricing/
 const Ai302: ModelProviderCard = {
-  apiKeyUrl: 'https://lobe.li/Oizw5sN',
+  apiKeyUrl: AI302_API_KEY_REFERRAL,
   chatModels: [
     {
       contextWindowTokens: 32_000,

--- a/src/config/modelProviders/aihubmix.ts
+++ b/src/config/modelProviders/aihubmix.ts
@@ -1,7 +1,19 @@
 import { ModelProviderCard } from '@/types/llm';
 
+import { buildHermesReferralUrl } from './utils/referral';
+
+// NOTE(HERMES-GROWTH-2025-02-18): Growth approved the AiHubMix referral slug to
+// keep attribution clean while their ops team retires the legacy lobe.li short
+// codes. The go.hermes.chat redirect preserves downstream partner tracking.
+const AIHUBMIX_API_KEY_REFERRAL = buildHermesReferralUrl({
+  destination: 'aihubmix-api-keys',
+  slug: 'aihubmix',
+});
+
+const AIHUBMIX_LANDING_REFERRAL = buildHermesReferralUrl({ slug: 'aihubmix' });
+
 const AiHubMix: ModelProviderCard = {
-  apiKeyUrl: 'https://lobe.li/9mZhb4T',
+  apiKeyUrl: AIHUBMIX_API_KEY_REFERRAL,
   chatModels: [],
   checkModel: 'gpt-4.1-nano',
   description: 'AiHubMix 通过统一的 API 接口提供对多种 AI 模型的访问。',
@@ -12,7 +24,10 @@ const AiHubMix: ModelProviderCard = {
     sdkType: 'router',
     showModelFetcher: true,
   },
-  url: 'https://aihubmix.com?utm_source=lobehub',
+  // Growth asked us to hold a short-lived redirect here while their analytics
+  // warehouse migrates dashboards off of the lobehub source. Once Segment is
+  // re-keyed we can collapse this into a direct AiHubMix deep link.
+  url: AIHUBMIX_LANDING_REFERRAL,
 };
 
 export default AiHubMix;

--- a/src/config/modelProviders/openai.ts
+++ b/src/config/modelProviders/openai.ts
@@ -1,8 +1,20 @@
 import { ModelProviderCard } from '@/types/llm';
 
+import { buildHermesReferralUrl } from './utils/referral';
+
+// NOTE(HERMES-GROWTH-2025-02-18): Growth asked us to route OpenAI account
+// creation through go.hermes.chat so Segment captures a consistent
+// provider-card attribution story across web, desktop, and mobile shells.
+const OPENAI_API_KEY_REFERRAL = buildHermesReferralUrl({
+  destination: 'openai-api-keys',
+  slug: 'openai',
+});
+
 // ref: https://platform.openai.com/docs/deprecations
 const OpenAI: ModelProviderCard = {
-  apiKeyUrl: 'https://platform.openai.com/api-keys?utm_source=lobehub',
+  // The Hermes shortlink preserves the direct OpenAI destination but guarantees
+  // the approved UTMs stay attached even if we rotate landing pages again.
+  apiKeyUrl: OPENAI_API_KEY_REFERRAL,
   chatModels: [
     {
       contextWindowTokens: 400_000,

--- a/src/config/modelProviders/ppio.ts
+++ b/src/config/modelProviders/ppio.ts
@@ -1,5 +1,22 @@
 import { ModelProviderCard } from '@/types/llm';
 
+import { buildHermesReferralUrl } from './utils/referral';
+
+// NOTE(HERMES-GROWTH-2025-02-18): PPIO relies on an invite code while their
+// partner dashboard catches up to Hermes tracking. The Growth pod asked us to
+// centralise both the model list and signup flows through go.hermes.chat so the
+// UTMs stay uniform across every surface.
+const PPIO_MODELS_REFERRAL = buildHermesReferralUrl({
+  destination: 'ppio-models',
+  slug: 'ppio',
+});
+
+const PPIO_SIGNUP_REFERRAL = buildHermesReferralUrl({
+  destination: 'ppio-signup',
+  extraParams: { invited_by: 'RQIMOC' },
+  slug: 'ppio',
+});
+
 const PPIO: ModelProviderCard = {
   chatModels: [
     {
@@ -159,15 +176,16 @@ const PPIO: ModelProviderCard = {
   disableBrowserRequest: true,
   id: 'ppio',
   modelList: { showModelFetcher: true },
-  modelsUrl:
-    'https://ppinfra.com/llm-api?utm_source=github_lobe-chat&utm_medium=github_readme&utm_campaign=link',
+  modelsUrl: PPIO_MODELS_REFERRAL,
   name: 'PPIO',
   settings: {
     disableBrowserRequest: true,
     sdkType: 'openai',
     showModelFetcher: true,
   },
-  url: 'https://ppinfra.com/user/register?invited_by=RQIMOC&utm_source=github_lobechat',
+  // Keep the invite code attached to the Hermes shortlink so PartnerOps can
+  // reconcile historical referrals while they finish migrating dashboards.
+  url: PPIO_SIGNUP_REFERRAL,
 };
 
 export default PPIO;

--- a/src/config/modelProviders/utils/referral.ts
+++ b/src/config/modelProviders/utils/referral.ts
@@ -1,0 +1,69 @@
+import { ModelProviderCard } from '@/types/llm';
+
+/**
+ * Default host for Hermes-branded referral deep links.
+ */
+export const HERMES_REFERRAL_HOST = 'https://go.hermes.chat';
+
+/**
+ * Canonical tracking taxonomy endorsed by Growth on 2025-02-18 for all
+ * in-product provider referrals. Aligning the defaults here keeps every card
+ * emitting consistent metrics without manual spreadsheet updates.
+ */
+export const HERMES_REFERRAL_UTM = {
+  campaign: 'model_provider',
+  medium: 'app_referral',
+  source: 'hermes-chat',
+} as const;
+
+export interface HermesReferralOptions {
+  /**
+   * Optional destination override. When omitted we use the slug directly.
+   */
+  readonly destination?: string;
+  /**
+   * Additional query parameters that must survive the redirect (e.g., partner
+   * invite codes, analytics flags).
+   */
+  readonly extraParams?: Record<string, string>;
+  /**
+   * Provider slug used for attribution and as the default path segment.
+   */
+  readonly slug: ModelProviderCard['id'];
+}
+
+function toPathSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^\da-z]+/g, '-');
+}
+
+/**
+ * Builds a Hermes referral deep link that funnels through the Growth-owned go
+ * service. Centralising this logic ensures all provider cards emit the same
+ * tracking story while still supporting provider-specific partner parameters.
+ */
+export const buildHermesReferralUrl = ({
+  destination,
+  extraParams,
+  slug,
+}: HermesReferralOptions): string => {
+  const pathSegment = destination ? toPathSegment(destination) : toPathSegment(slug);
+  const url = new URL(`/r/${pathSegment}`, HERMES_REFERRAL_HOST);
+
+  // Growth specifically asked that we stamp the provider slug into utm_content
+  // so downstream dashboards can pivot by provider without custom Looker views.
+  url.searchParams.set('utm_source', HERMES_REFERRAL_UTM.source);
+  url.searchParams.set('utm_medium', HERMES_REFERRAL_UTM.medium);
+  url.searchParams.set('utm_campaign', HERMES_REFERRAL_UTM.campaign);
+  url.searchParams.set('utm_content', toPathSegment(slug));
+
+  if (extraParams) {
+    for (const [key, value] of Object.entries(extraParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  return url.toString();
+};

--- a/tests/scripts/rebrandHermesChat.test.ts
+++ b/tests/scripts/rebrandHermesChat.test.ts
@@ -88,7 +88,7 @@ async function createWorkspace(): Promise<string> {
 
   await writeFile(
     join(workspace, 'docs.md'),
-    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nLegacy domains: https://lobechat.com + https://www.lobechat.com\nRaw asset: https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/logo.svg\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @hermeslabs/ui\nScoped migration: @lobechat/analytics\nSocial: Follow us @lobehub!\nCommunity beta: say hi at @lobechat.\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nLocale cookie constant: LOBE_LOCALE\nDesktop UA: LobeChat-Desktop/1.0.0\nMarkdown sample: \`lobe_chat\`\nCloud constant: LOBE_CHAT_CLOUD\nCloud slug: lobe-chat-cloud\nCloud snake: lobe_chat_cloud\nCloud label: Lobe Chat Cloud\nProvider slug: 'lobehub'\n`,
+    `# LobeChat\n\nLobeChat by LobeHub lives at https://lobehub.com and https://cdn.lobehub.com.\nLegacy domains: https://lobechat.com + https://www.lobechat.com\nRaw asset: https://raw.githubusercontent.com/lobehub/lobe-chat/main/assets/logo.svg\nSupport: https://help.lobehub.com\nContact support@lobehub.com or hello@lobehub.com.\nRepo: https://github.com/lobehub/lobe-chat.\nURN: urn:lobehub:chat\nPackage: @hermeslabs/ui\nScoped migration: @lobechat/analytics\nSocial: Follow us @lobehub!\nCommunity beta: say hi at @lobechat.\nAsset: /assets/logo/lobehub.svg\nDocker service: lobe-chat\nHelm release: LOBE-CHAT\nEnvironment constant: LOBE_CHAT\nLocale cookie constant: LOBE_LOCALE\nDesktop UA: LobeChat-Desktop/1.0.0\nMarkdown sample: \`lobe_chat\`\nCloud constant: LOBE_CHAT_CLOUD\nCloud slug: lobe-chat-cloud\nCloud snake: lobe_chat_cloud\nCloud label: Lobe Chat Cloud\nProvider slug: 'lobehub'\nPPIO referral: https://ppinfra.com/user/register?invited_by=RQIMOC&utm_source=github_lobechat&utm_medium=github_readme&utm_campaign=link\nAiHubMix docs: https://aihubmix.com?utm_source=lobehub&utm_medium=github_readme&utm_campaign=link\n`,
     'utf8',
   );
 
@@ -192,6 +192,11 @@ describe('rebrandHermesChat CLI', () => {
       expect(docs).toContain('Cloud snake: hermes_qa_cloud');
       expect(docs).toContain('Cloud label: Hermes Chat QA Cloud');
       expect(docs).toContain("Provider slug: 'hermescloud'");
+      expect(docs).toContain('utm_source=hermes-chat');
+      expect(docs).toContain('utm_medium=app_referral');
+      expect(docs).toContain('utm_campaign=model_provider');
+      expect(docs).not.toContain('github_lobechat');
+      expect(docs).not.toContain('utm_source=lobehub');
       expect(docs).not.toContain('LobeChat');
       expect(docs).not.toContain('lobehub.com');
       expect(docs).not.toContain('lobechat.com');
@@ -251,6 +256,10 @@ describe('rebrandHermesChat CLI', () => {
       expect(combinedOutput).toContain('cloud-token-title');
       expect(combinedOutput).toContain('cloud-token-kebab');
       expect(combinedOutput).toContain('cloud-token-snake');
+      expect(combinedOutput).toContain('utm-source-lobehub');
+      expect(combinedOutput).toContain('utm-source-github-lobechat');
+      expect(combinedOutput).toContain('utm-medium-github-readme');
+      expect(combinedOutput).toContain('utm-campaign-link');
       expect(combinedOutput).toContain('dry-run replacement summary');
 
       const after = await readFile(join(workspace, 'docs.md'), 'utf8');


### PR DESCRIPTION
## Summary
- centralize Hermes referral URL construction and migrate providers to Growth-approved tracking slugs
- teach the rebranding automation and tests to rewrite legacy UTM patterns while surfacing audit counts
- document the Hermes referral policy for developers and operators plus add regression coverage for provider cards

## Testing
- bunx vitest run --silent='passed-only' 'src/config/modelProviders/__tests__/referralLinks.test.ts'
- bunx vitest run --silent='passed-only' 'tests/scripts/rebrandHermesChat.test.ts'

------
https://chatgpt.com/codex/tasks/task_e_68e2ab383280832e9c62406a3941d449