### PR TITLE
Add enterprise readiness epics and stories

### DIFF
--- a/backlog/01_epics.hermes-chat.yaml
+++ b/backlog/01_epics.hermes-chat.yaml
@@ -160,3 +160,298 @@ epics:
       - >-
         Add Hermes Chat launch runbook to `docs/changelog/2025-hermes-chat-launch.md` and link to training
         decks for sales, support, and partners.
+
+  - id: EPIC-HC-005
+    name: Identity, Tenancy, and Compliance Foundations
+    description: >-
+      Deliver enterprise-grade authentication, authorization, and tenant isolation with centralized key
+      custody so regulated customers can adopt Hermes Chat without manual exception handling.
+    business_rationale: >-
+      Enterprise buyers require SSO, RBAC, auditability, and compliant key management (Vault/THEMIS) before
+      allowing sensitive workloads onto the platform; failing to provide these blocks P0 deals.
+    dependencies:
+      - EPIC-HC-003 # Production domains must exist before wiring SSO callbacks and audit exports.
+    acceptance_criteria:
+      - >-
+        OIDC/SAML SSO (Okta, Entra ID, Google) enforced for all interactive logins via NextAuth gateway with
+        password/email login disabled by feature flag.
+      - >-
+        Multi-tenant workspace model (Organization → Project) with Owner/Admin/Editor/Viewer roles enforced
+        across API, chat sessions, knowledge base, and plugin execution paths.
+      - >-
+        Provider credentials never leave the server tier: keys stored in Vault/THEMIS and proxied through
+        a hardened service that applies per-tenant quotas and rate limits, with rotations audited.
+      - >-
+        THEMIS audit hooks emit append-only SAIG-compatible events for chat prompts, tool calls, file ingest,
+        and erase/export operations with verifiable hash chains.
+      - >-
+        Data classification, PII redaction, retention, and legal hold policies configurable per tenant with
+        documented admin workflows and automated expiry jobs.
+    testing_expectations:
+      - >-
+        End-to-end tests in `tests/e2e/identity/*.spec.ts` validate SSO enforcement, role-guarded routes,
+        and tenant isolation including forbidden cross-tenant access attempts.
+      - >-
+        Security regression suite executes `bun run test:security` to fuzz the key proxy and audit log
+        append-only guarantees with deterministic fixtures.
+      - >-
+        Compliance smoke tests verify retention + legal hold timers via time-travel integration tests running
+        against ephemeral Postgres + Vault containers in CI.
+    automation_expectations:
+      - >-
+        Terraform/Terragrunt modules manage Vault/THEMIS policies and Okta/Entra app registrations,
+        triggered from GitHub Actions with OIDC federation to eliminate manual secret handling.
+      - >-
+        GitHub Actions workflow `ci/compliance.yml` gates merges on successful SSO contract tests, RBAC policy
+        unit tests, and audit log schema validation.
+    documentation_expectations:
+      - >-
+        Expand `docs/usage/enterprise-security.md` with SSO onboarding, key custody diagrams, audit export
+        recipes, and retention playbooks.
+
+  - id: EPIC-HC-006
+    name: Mnemosyne Memory & Knowledge Platform Integration
+    description: >-
+      Replace ad-hoc vector storage with Mnemosyne federated memory, delivering namespace isolation,
+      summarization controls, and automated knowledge governance across ingestion and retrieval.
+    business_rationale: >-
+      Aligning with Apotheon.ai stack unlocks shared federated memory features and reduces maintenance of
+      bespoke vector infrastructure, while enabling decay policies demanded by compliance teams.
+    dependencies:
+      - EPIC-HC-005 # Tenant hierarchy and retention policies drive namespace + TTL configuration.
+    acceptance_criteria:
+      - >-
+        All retrieval-augmented workflows route through Mnemosyne SDK with per-tenant/project namespaces and
+        configurable summarization/decay knobs stored in the admin console.
+      - >-
+        Ingestion pipeline performs adaptive chunking, MIME validation, malware scanning, and PII redaction
+        before persisting embeddings, with failures surfaced via admin alerts.
+      - >-
+        Legal hold and retention controls propagate to Mnemosyne, generating deletion receipts linked to
+        THEMIS audit entries.
+    testing_expectations:
+      - >-
+        Contract tests run against Mnemosyne sandbox using `bunx vitest run --silent='passed-only' 'tests/mnemosyne/*'`
+        covering namespace isolation, summarization toggles, and decay scheduling.
+      - >-
+        Load tests (`bun run test:load:mnemosyne`) validate throughput and latency budgets at enterprise scale
+        with synthetic tenants.
+    automation_expectations:
+      - >-
+        CI pipelines provision ephemeral Mnemosyne namespaces via API for integration tests, and Terraform
+        modules manage production tiers with automated drift detection.
+    documentation_expectations:
+      - >-
+        Update `docs/architecture/memory.md` with Mnemosyne topology diagrams, retention knobs, and operational
+        runbooks for ingestion + replay tooling.
+
+  - id: EPIC-HC-007
+    name: URS/Hermes Orchestration & Playbook Automation
+    description: >-
+      Expose URS DAG execution from chat, enabling operators to launch playbooks with approvals, SLA tracking,
+      and compensating actions directly within the Hermes Chat workspace.
+    business_rationale: >-
+      Enterprise teams require auditable, semi-automated runbooks that integrate with Hermes orchestration to
+      drive high-value workflows and reduce swivel-chair operations.
+    dependencies:
+      - EPIC-HC-005 # RBAC + approvals rely on tenant-aware policies.
+      - EPIC-HC-006 # Playbooks often reference Mnemosyne memories and KB artifacts.
+    acceptance_criteria:
+      - >-
+        Chat UI surfaces "Run Playbook" action with searchable URS catalog, input validation, SLA metadata,
+        and progress tracking for each DAG node including compensations.
+      - >-
+        Approval workflows support multi-step human-in-the-loop gates, break-glass overrides, and audit hooks
+        to THEMIS capturing requester, approver, and execution metadata.
+      - >-
+        Failure handling triggers compensating actions and notifies relevant roles via Slack/Teams webhooks
+        with retriable state machine entries.
+    testing_expectations:
+      - >-
+        Scenario tests in `tests/e2e/playbooks/*.spec.ts` cover DAG execution, approval gating, break-glass,
+        and rollback logic with mocked URS endpoints.
+      - >-
+        Contract tests validate URS API schemas using `bunx vitest run --silent='passed-only' 'tests/contract/urs*'`.
+    automation_expectations:
+      - >-
+        GitHub Actions pipeline publishes URS schema stubs to an internal registry and syncs with the chat
+        app automatically, preventing manual copy/paste of protobuf/JSON definitions.
+    documentation_expectations:
+      - >-
+        Document playbook lifecycle, approvals, and rollback procedures in `docs/usage/runbooks.md` with
+        screenshots and example DAG definitions.
+
+  - id: EPIC-HC-008
+    name: Clio Voice & Morpheus Media Experiences
+    description: >-
+      Integrate Clio streaming voice (VAD, STT, TTS) and Morpheus long-running media generation into the chat
+      experience with resilient fallbacks and artifact management.
+    business_rationale: >-
+      Voice and media workflows expand Hermes Chat's applicability to frontline and creative teams, aligning
+      with Apotheon.ai ecosystem commitments.
+    dependencies:
+      - EPIC-HC-005 # RBAC determines who can access voice/media features.
+      - EPIC-HC-006 # Generated artifacts may reference Mnemosyne storage policies.
+    acceptance_criteria:
+      - >-
+        Voice mode enables real-time transcription and TTS using Clio endpoints with WebRTC transport, VAD,
+        and fallback to Lobe TTS if Clio is unavailable.
+      - >-
+        Morpheus job queue handles image/video generation with progress updates, resumable polling, and an
+        artifact gallery scoped per tenant with retention controls.
+      - >-
+        Network resiliency includes circuit breakers and retry policies for Clio/Morpheus endpoints with
+        observability (metrics/traces) exported to the shared telemetry stack.
+    testing_expectations:
+      - >-
+        Web integration tests simulate degraded networks ensuring graceful fallback from Clio to Lobe TTS and
+        verifying audio synchronization.
+      - >-
+        Backend integration tests cover Morpheus job lifecycle, artifact storage, and RBAC enforcement using
+        deterministic fixtures.
+    automation_expectations:
+      - >-
+        CI mocks Clio/Morpheus via contract snapshots automatically regenerated from upstream schemas to
+        detect breaking changes early.
+    documentation_expectations:
+      - >-
+        Expand `docs/usage/voice-media.md` with setup instructions, supported codecs, retention policies, and
+        troubleshooting guides for admins and end users.
+
+  - id: EPIC-HC-009
+    name: Observability, Feature Flags, and SRE Controls
+    description: >-
+      Instrument Hermes Chat end-to-end with OpenTelemetry, quota enforcement, kill switches, and automated
+      circuit breakers to meet enterprise SLOs and compliance observability requirements.
+    business_rationale: >-
+      Enterprise readiness demands real-time visibility, throttling, and rapid mitigation capabilities across
+      multi-tenant infrastructure.
+    dependencies:
+      - EPIC-HC-005 # Tenant metadata powers dashboards and quotas.
+    acceptance_criteria:
+      - >-
+        OpenTelemetry traces span frontend → gateway → providers/plugins with tenant/context attributes and
+        flow into Grafana/Tempo dashboards.
+      - >-
+        Feature flag service (e.g., OpenFeature) enables ops-controlled toggles, including provider kill-switch
+        and plugin allowlist enforcement.
+      - >-
+        Automated circuit breakers throttle providers/plugins on error surges and emit alerts to on-call.
+      - >-
+        Usage analytics + quotas surface in admin console with exportable billing hooks.
+    testing_expectations:
+      - >-
+        Chaos experiments (`bun run test:chaos`) validate circuit breaker thresholds and recovery paths.
+      - >-
+        Telemetry integration tests confirm trace/span propagation and sampling policies under load.
+    automation_expectations:
+      - >-
+        GitHub Actions enforces observability schema via `otel-lint` job and deploys flag definitions through
+        Infrastructure-as-Code to prevent drift.
+    documentation_expectations:
+      - >-
+        Publish `docs/operations/observability.md` covering dashboards, alert routing, and feature flag SOPs.
+
+  - id: EPIC-HC-010
+    name: Plugin & MCP Ecosystem Hardening
+    description: >-
+      Curate internal plugins (THEMIS, Mnemosyne, URS, Clio, Morpheus, Jarvis) with granular permissions,
+      egress controls, and sandboxing to safely extend Hermes Chat.
+    business_rationale: >-
+      Enterprises require vetted integrations and the ability to restrict plugin capabilities for regulatory
+      compliance and data governance.
+    dependencies:
+      - EPIC-HC-005 # RBAC + tenant metadata determine plugin visibility.
+      - EPIC-HC-009 # Observability + kill-switch instrumentation shared with plugin layer.
+    acceptance_criteria:
+      - >-
+        Plugin catalog distinguishes curated/internal plugins with metadata (scopes, data classification)
+        and enforces permission prompts and egress allowlists before activation.
+      - >-
+        Untrusted plugin execution isolated via WASM sandbox with resource quotas and audit logging.
+      - >-
+        Admin console surfaces plugin analytics, kill-switches, and approval workflows integrated with THEMIS.
+    testing_expectations:
+      - >-
+        Security tests attempt sandbox escapes, egress violations, and unauthorized data access with automated
+        fuzzing harnesses executed nightly.
+      - >-
+        Contract tests ensure plugin manifests comply with Hermes MCP schema via `bunx vitest run --silent='passed-only' 'tests/plugins/*'`.
+    automation_expectations:
+      - >-
+        Plugin publishing pipeline signs manifests, pushes to internal registry, and updates documentation via
+        automated PRs.
+    documentation_expectations:
+      - >-
+        Update `docs/plugins/catalog.md` describing each plugin, permission scopes, and sandbox controls with
+        runbooks for security reviews.
+
+  - id: EPIC-HC-011
+    name: Desktop Distribution & Policy Enforcement
+    description: >-
+      Harden the Electron desktop app with code signing, auto-updates, and enterprise policy packs enforcing
+      SSO-only authentication and restricted local capabilities.
+    business_rationale: >-
+      Desktop deployments in regulated industries require signed binaries, managed updates, and admin
+      controls to pass security assessments.
+    dependencies:
+      - EPIC-HC-005 # SSO enforcement + RBAC apply to desktop clients.
+      - EPIC-HC-009 # Feature flags + kill-switch must propagate to desktop runtime.
+    acceptance_criteria:
+      - >-
+        macOS and Windows builds signed via automated CI/CD, published to GHCR with notarization logs stored
+        for audits.
+      - >-
+        Auto-update channel supports staged rollout, rollback, and policy enforcement (disable local file I/O,
+        enforce SSO) managed centrally.
+      - >-
+        Desktop telemetry integrates with OpenTelemetry stack and respects tenant retention policies.
+    testing_expectations:
+      - >-
+        Desktop controller tests validate policy enforcement, update flows, and offline login denial.
+      - >-
+        Smoke tests run via Playwright on signed builds to ensure core chat flows remain functional.
+    automation_expectations:
+      - >-
+        GitHub Actions pipeline builds, signs, notarizes, and publishes installers automatically using secure
+        code-signing service accounts.
+    documentation_expectations:
+      - >-
+        Document desktop deployment + policy configuration in `docs/desktop/enterprise-deployment.md`.
+
+  - id: EPIC-HC-012
+    name: Enterprise Onboarding & UX Accelerators
+    description: >-
+      Deliver guided onboarding, knowledge base ingestion, and agent templates tailored for enterprise
+      compliance, reducing time-to-value and minimizing manual setup steps.
+    business_rationale: >-
+      Streamlined onboarding and reusable agent templates differentiate Hermes Chat in competitive RFPs and
+      reduce implementation effort for customer success teams.
+    dependencies:
+      - EPIC-HC-005 # Workspace + RBAC contexts drive onboarding flows.
+      - EPIC-HC-006 # Knowledge ingestion relies on Mnemosyne integration.
+    acceptance_criteria:
+      - >-
+        First-run enterprise onboarding wizard covers SSO connection, provider routing, rate limits, and
+        agent kit import with progress save + resume.
+      - >-
+        Knowledge base ingestion workflow offers health scoring, token budget guidance, doc-level ACLs, and
+        automated validation (virus scan, chunking preview, retention tags).
+      - >-
+        Library of enterprise agent templates (Compliance Reviewer, Data Steward, Red Team Assistant) shipped
+        with documentation, observability hooks, and audit-ready prompts.
+    testing_expectations:
+      - >-
+        Guided onboarding e2e tests verify wizard steps, error handling, and resumption logic under network
+        interruptions.
+      - >-
+        Knowledge ingestion tests simulate large document batches ensuring automation handles chunking,
+        redaction, and ACL assignment.
+    automation_expectations:
+      - >-
+        Onboarding wizard triggers backend automation to provision providers, rate limits, and sample agents
+        via idempotent jobs—no manual console work required.
+    documentation_expectations:
+      - >-
+        Update `docs/usage/onboarding-enterprise.md` and create agent template playbooks with governance notes
+        and recommended monitoring dashboards.

--- a/backlog/02_stories_and_tasks.hermes-chat.yaml
+++ b/backlog/02_stories_and_tasks.hermes-chat.yaml
@@ -439,3 +439,386 @@ stories:
           - Validate dashboards using screenshot diffs stored under `tests/analytics/dashboard-visual.spec.ts`.
         documentation:
           - Capture metric definitions + owners in `docs/development/analytics.md` appendix.
+
+  - id: STORY-HC-101
+    epic_id: EPIC-HC-005
+    title: Enforce enterprise SSO and foundational RBAC guardrails
+    priority: P0
+    description: >-
+      Implement mandatory OIDC/SAML SSO across the Next.js gateway, codify organization/project hierarchy, and enforce
+      Owner/Admin/Editor/Viewer roles for web, API, and plugin paths.
+    acceptance_criteria:
+      - >-
+        NextAuth (or custom OIDC) flows configured for Okta, Entra ID, and Google with IdP metadata stored in Vault and SSO
+        enforced via feature flag toggle.
+      - >-
+        Organization, Project, MemberRole, and Invitation models migrated via Drizzle with tenant-aware foreign keys and
+        optimistic concurrency controls.
+      - >-
+        API and UI routes guarded by reusable RBAC middleware returning 403 for unauthorized roles and logging attempts to THEMIS.
+    testing:
+      - >-
+        Add e2e coverage in `tests/e2e/identity/sso.spec.ts` for sign-in, logout, session refresh, and disabled password login fallback.
+      - >-
+        Implement RBAC unit tests (`bunx vitest run --silent='passed-only' 'tests/unit/rbac/*'`) verifying guard behavior across permutations.
+    documentation:
+      - >-
+        Document SSO onboarding and RBAC hierarchy in `docs/usage/enterprise-security.md` with IdP-specific setup instructions.
+    tasks:
+      - id: TASK-HC-101A
+        type: engineering
+        owner: identity-platform
+        description: >-
+          Wire NextAuth custom provider adapters for Okta, Entra ID, and Google with PKCE + nonce validation, storing client secrets
+          in Vault/THEMIS and retrieving via signed service tokens.
+        references:
+          - apps/web/app/api/auth/[...nextauth]/route.ts
+          - packages/server/auth/
+          - scripts/vault/
+        automation:
+          - Terraform module `infra/identity/` provisions IdP applications and exports metadata to Vault.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/unit/auth/*'` plus `tests/e2e/identity/sso.spec.ts`.
+        documentation:
+          - Update `docs/self-hosting/sso.md` with automated setup script usage and rollback steps.
+      - id: TASK-HC-101B
+        type: engineering
+        owner: platform-core
+        description: >-
+          Introduce Organization, Project, Membership, and Role tables via Drizzle migrations with tenant-aware policies enforced in Postgres
+          Row Level Security and mirrored in application middleware.
+        references:
+          - drizzle/schema/
+          - src/server/rbac/
+        automation:
+          - Add migration verification to `scripts/db/verify-migrations.ts` ensuring RLS + policies exist.
+        testing:
+          - Execute `bunx vitest run --silent='passed-only' 'tests/unit/rbac/*'` and new integration tests in `tests/integration/db/rbac.spec.ts`.
+        documentation:
+          - Extend `docs/development/database.md` with ERD diagrams and tenancy notes.
+      - id: TASK-HC-101C
+        type: engineering
+        owner: security-engineering
+        description: >-
+          Build reusable RBAC guard middleware for Next.js (server actions, API routes) and plugin execution contexts, instrumenting denied attempts
+          to THEMIS audit log stream.
+        references:
+          - src/server/middleware/rbac.ts
+          - packages/plugins/
+        automation:
+          - Register audit schema in `scripts/audit/register_schema.ts` to auto-validate payloads during CI.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/unit/middleware/rbacGuard.spec.ts'` and e2e regression suite.
+        documentation:
+          - Update `docs/usage/enterprise-security.md` guardrail sections with troubleshooting tips.
+
+  - id: STORY-HC-102
+    epic_id: EPIC-HC-005
+    title: Vault-backed provider key proxy with quotas and audit trails
+    priority: P0
+    description: >-
+      Centralize provider credential storage in Vault/THEMIS, serve requests through a proxy enforcing quotas/rate limits, and emit SAIG-compatible
+      audit events for every key usage.
+    acceptance_criteria:
+      - >-
+        Key proxy exposes REST/gRPC endpoints for model/tool invocations without exposing raw credentials to clients; per-tenant quotas configurable via
+        admin console.
+      - >-
+        THEMIS audit log stream records key issuance, usage, rotation, and revocation with verifiable hash chain.
+      - >-
+        Client applications load credentials via short-lived signed tokens scoped to tenant + model.
+    testing:
+      - >-
+        Security regression harness (`bun run test:security`) fuzzes proxy rate limits and leakage scenarios.
+      - >-
+        Integration tests in `tests/integration/key-proxy.spec.ts` validate quota enforcement and audit events.
+    documentation:
+      - >-
+        Document key custody model and rotation workflows in `docs/usage/enterprise-security.md` and `docs/operations/key-proxy.md`.
+    tasks:
+      - id: TASK-HC-102A
+        type: engineering
+        owner: security-engineering
+        description: >-
+          Implement NestJS (or Fastify) microservice backed by Vault/THEMIS for credential storage, issuing short-lived signed tokens and forwarding
+          provider calls with quota enforcement.
+        references:
+          - apps/services/key-proxy/
+          - packages/sdk/
+        automation:
+          - GitHub Actions deploy job publishes container to GHCR and provisions Vault roles automatically.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'apps/services/key-proxy/tests/*'` plus integration suites.
+        documentation:
+          - Update service README with deployment + monitoring instructions.
+      - id: TASK-HC-102B
+        type: engineering
+        owner: compliance-ops
+        description: >-
+          Wire THEMIS audit emitters for key lifecycle events, generating SAIG-compatible append-only logs and providing CLI `audit_export --since --tenant`
+          for compliance teams.
+        references:
+          - packages/audit/
+          - scripts/audit/
+        automation:
+          - Schedule nightly export verification job uploading Merkle proofs to secure storage.
+        testing:
+          - Execute `bunx vitest run --silent='passed-only' 'tests/unit/audit/*'` and golden file comparisons.
+        documentation:
+          - Document audit export/verification in `docs/operations/audit.md`.
+
+  - id: STORY-HC-103
+    epic_id: EPIC-HC-006
+    title: Mnemosyne-backed ingestion pipeline with retention and redaction
+    priority: P0
+    description: >-
+      Replace local vector ingestion with Mnemosyne SDK, layering adaptive chunking, virus scanning, PII redaction, and tenant-specific retention/legal hold controls.
+    acceptance_criteria:
+      - >-
+        Ingestion workers push embeddings to Mnemosyne using per-tenant namespaces and emit deletion receipts during retention expiry or manual erasure.
+      - >-
+        Knowledge ingestion UI surfaces health metrics (token usage, redaction status) and blocks promotion when scans fail.
+      - >-
+        Legal hold toggles prevent deletion while logging overrides to THEMIS.
+    testing:
+      - >-
+        Run `bunx vitest run --silent='passed-only' 'tests/mnemosyne/ingestion.spec.ts'` covering happy/edge paths.
+      - >-
+        Integration tests simulate large document batches via `tests/perf/ingestion.load.ts` to validate scaling.
+    documentation:
+      - >-
+        Update `docs/architecture/memory.md` and ingestion runbooks with pipeline diagrams and automation scripts.
+    tasks:
+      - id: TASK-HC-103A
+        type: engineering
+        owner: knowledge-platform
+        description: >-
+          Build ingestion orchestrator (BullMQ/Temporal) that runs virus scan, MIME validation, adaptive chunking, and PII redaction before submitting to Mnemosyne.
+        references:
+          - apps/services/ingestion/
+          - packages/workers/
+        automation:
+          - Terraform-managed Redis/Temporal clusters with autoscaling metrics.
+        testing:
+          - Execute worker unit tests and pipeline integration suites with mocked Mnemosyne endpoints.
+        documentation:
+          - Add pipeline walkthrough to `docs/architecture/memory.md`.
+      - id: TASK-HC-103B
+        type: engineering
+        owner: compliance-ops
+        description: >-
+          Implement retention + legal hold engine storing policies per tenant/project, scheduling expirations, and writing THEMIS audit events upon deletion or hold toggles.
+        references:
+          - packages/compliance/
+          - drizzle/schema/compliance.ts
+        automation:
+          - Scheduled job `scripts/compliance/enforce_retention.ts` runs via GitHub Actions workflow dispatch.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/unit/compliance/*'` plus time-travel integration tests.
+        documentation:
+          - Extend compliance docs with policy configuration and SLA expectations.
+
+  - id: STORY-HC-104
+    epic_id: EPIC-HC-007
+    title: Chat-triggered URS playbook execution with approvals
+    priority: P1
+    description: >-
+      Allow users to discover, parameterize, and execute URS playbooks directly from chat while capturing approvals, SLAs, and compensating actions with full audit coverage.
+    acceptance_criteria:
+      - >-
+        Chat UI lists available playbooks with search/filter, input validation, and SLA metadata surfaced.
+      - >-
+        Execution timeline modal displays DAG progress, retries, compensations, and links to underlying logs.
+      - >-
+        Approvals require RBAC-authorized reviewers; break-glass overrides emit dedicated audit events.
+    testing:
+      - >-
+        e2e tests in `tests/e2e/playbooks/chat-runner.spec.ts` simulate approval and break-glass flows.
+      - >-
+        Contract tests validate URS schema compatibility and error handling for timeouts.
+    documentation:
+      - >-
+        Update `docs/usage/runbooks.md` with screenshots and SOPs for approvals + rollback.
+    tasks:
+      - id: TASK-HC-104A
+        type: engineering
+        owner: orchestration-platform
+        description: >-
+          Implement chat-side panel to browse playbooks, capture input forms (zod schemas), and stream status updates via SSE/WebSocket from URS orchestrator.
+        references:
+          - apps/web/app/(dashboard)/chat/
+          - packages/urs-client/
+        automation:
+          - Generate playbook TypeScript types automatically from URS schema repository via `bun run sync:urs`.
+        testing:
+          - Run component tests with Testing Library and e2e suites for streaming updates.
+        documentation:
+          - Document UI patterns in `docs/development/design-system.md` runbook section.
+      - id: TASK-HC-104B
+        type: engineering
+        owner: security-engineering
+        description: >-
+          Build approval workflow service storing pending approvals, enforcing RBAC checks, and logging decisions to THEMIS including break-glass overrides and SLA breaches.
+        references:
+          - packages/approvals/
+          - drizzle/schema/approvals.ts
+        automation:
+          - Scheduled SLA monitor job posts alerts to Ops Slack when deadlines breach.
+        testing:
+          - Run unit + integration tests ensuring multi-approver requirements and compensating action triggers.
+        documentation:
+          - Update compliance + ops runbooks with approval procedures.
+
+  - id: STORY-HC-105
+    epic_id: EPIC-HC-008
+    title: Clio-powered streaming voice mode with Lobe fallback
+    priority: P1
+    description: >-
+      Deliver a low-latency voice chat experience backed by Clio STT/TTS with WebRTC transport, VAD, and automatic fallback to Lobe TTS when Clio endpoints are degraded.
+    acceptance_criteria:
+      - >-
+        Web client captures microphone audio, performs on-device VAD, streams to Clio, and plays synthesized responses with <250ms added latency on stable connections.
+      - >-
+        Fallback to Lobe TTS triggered by health monitor with user notification and audit trail.
+      - >-
+        Voice transcripts stored in Mnemosyne with retention policies applied.
+    testing:
+      - >-
+        Integration tests stub Clio + Lobe endpoints verifying fallback logic and latency budgets.
+      - >-
+        Browser automation via Playwright validates microphone permissions and audio playback.
+    documentation:
+      - >-
+        Update `docs/usage/voice-media.md` with configuration steps and troubleshooting.
+    tasks:
+      - id: TASK-HC-105A
+        type: engineering
+        owner: realtime-experience
+        description: >-
+          Build WebRTC transport layer with adaptive bitrate, Clio endpoint negotiation, and metrics hooks for OpenTelemetry spans.
+        references:
+          - apps/web/app/(dashboard)/voice/
+          - packages/realtime/
+        automation:
+          - Health monitor cron pings Clio/Lobe endpoints and updates feature flag toggles automatically.
+        testing:
+          - Run WebRTC unit tests and Playwright coverage for microphone flows.
+        documentation:
+          - Document architecture in `docs/architecture/voice.md`.
+      - id: TASK-HC-105B
+        type: engineering
+        owner: platform-core
+        description: >-
+          Persist voice transcripts + metadata to Mnemosyne with tenant-aware namespaces and retention, exposing download + erase flows respecting legal hold.
+        references:
+          - packages/mnemosyne/
+          - apps/web/app/api/voice/
+        automation:
+          - Scheduled retention job ensures transcripts expire per policy and logs outcomes.
+        testing:
+          - Execute ingestion integration tests ensuring transcripts link to chat sessions.
+        documentation:
+          - Update retention policy docs with voice-specific details.
+
+  - id: STORY-HC-106
+    epic_id: EPIC-HC-009
+    title: End-to-end OpenTelemetry with quotas, feature flags, and kill-switches
+    priority: P1
+    description: >-
+      Instrument Hermes Chat frontend/backend/plugins with OpenTelemetry spans, implement tenant-aware quotas, and deliver ops-managed feature flags + kill-switches.
+    acceptance_criteria:
+      - >-
+        Frontend instrumentation exports traces via OpenTelemetry SDK to gateway, including tenant/workspace tags.
+      - >-
+        Feature flag service integrates with RBAC to restrict toggles to owners and exposes audit history.
+      - >-
+        Quota engine enforces tenant usage caps with admin dashboard visibility and alerts.
+    testing:
+      - >-
+        Chaos tests simulate provider outages verifying kill-switch + circuit breaker activation.
+      - >-
+        Telemetry integration tests assert span propagation across async boundaries.
+    documentation:
+      - >-
+        Update `docs/operations/observability.md` with dashboards, runbooks, and flag workflows.
+    tasks:
+      - id: TASK-HC-106A
+        type: engineering
+        owner: sre-platform
+        description: >-
+          Integrate OpenTelemetry SDK in Next.js app, gateway, and worker services, exporting traces/metrics to Grafana stack with tenant attributes and exemplars.
+        references:
+          - apps/web/
+          - packages/server/
+          - scripts/observability/
+        automation:
+          - CI job `ci/otel-verify.yml` validates schema + sampling configs before deploy.
+        testing:
+          - Run telemetry integration tests and snapshot metrics to ensure budgets.
+        documentation:
+          - Update observability docs with instrumentation specifics.
+      - id: TASK-HC-106B
+        type: engineering
+        owner: platform-core
+        description: >-
+          Implement quota + rate limit engine tied to tenant billing plans, expose dashboards, and integrate with feature flag service for kill-switch automation.
+        references:
+          - packages/quotas/
+          - apps/web/app/(dashboard)/admin/
+        automation:
+          - Scheduled job publishes usage metrics to billing providers and enforces kill-switch triggers.
+        testing:
+          - Execute quota engine unit tests and e2e scenarios for throttle + alert flows.
+        documentation:
+          - Extend admin guide with quota configuration instructions.
+
+  - id: STORY-HC-107
+    epic_id: EPIC-HC-011
+    title: Signed desktop builds with enterprise policy pack
+    priority: P2
+    description: >-
+      Automate signed macOS/Windows desktop builds, enable auto-update with staged rollout, and ship policy pack enforcing SSO-only login plus restricted local capabilities.
+    acceptance_criteria:
+      - >-
+        CI/CD pipeline builds, signs, notarizes, and publishes installers with integrity artifacts stored securely.
+      - >-
+        Desktop app enforces SSO-only login with offline denial and surfaces policy status in settings.
+      - >-
+        Policy pack toggles (disable local file I/O, clipboard restrictions) centrally managed and audit logged.
+    testing:
+      - >-
+        Desktop controller tests cover policy enforcement; Playwright smoke suite validates chat flows on signed builds.
+      - >-
+        Auto-update integration tests confirm staged rollout + rollback.
+    documentation:
+      - >-
+        Update `docs/desktop/enterprise-deployment.md` with signing pipeline, rollout strategy, and policy config.
+    tasks:
+      - id: TASK-HC-107A
+        type: engineering
+        owner: desktop-platform
+        description: >-
+          Configure GitHub Actions to build Electron app for macOS/Windows, integrate with secure code-signing service, notarize macOS binaries, and publish to GHCR with release notes.
+        references:
+          - apps/desktop/
+          - .github/workflows/desktop-release.yml
+        automation:
+          - Use reusable workflow + secrets OIDC to fetch signing certificates on-demand.
+        testing:
+          - Run Playwright smoke tests against produced installers.
+        documentation:
+          - Document pipeline configuration and troubleshooting.
+      - id: TASK-HC-107B
+        type: engineering
+        owner: security-engineering
+        description: >-
+          Implement policy enforcement module in Electron main process locking down local file I/O, clipboard, and enforcing SSO token checks with remote configuration.
+        references:
+          - apps/desktop/src/main/
+          - packages/policies/
+        automation:
+          - Feature flag toggles retrieved from central service with signed configs and fallback cache.
+        testing:
+          - Execute desktop unit tests per `testing-guide/electron-ipc-test.mdc` and manual QA sign-off script.
+        documentation:
+          - Update policy pack section in enterprise deployment guide.


### PR DESCRIPTION
## Summary
- expand the Hermes Chat epics backlog with identity, compliance, Mnemosyne, orchestration, media, observability, plugin, desktop, and onboarding programs
- add detailed stories and tasks covering SSO, RBAC, key proxy, Mnemosyne ingestion, URS playbooks, Clio voice, telemetry, and desktop policy delivery

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e315a588f4832e908a482322c2632b