### PR TITLE
Add EPIC-HC-012 onboarding automation backlog

### DIFF
--- a/backlog/02_stories_and_tasks.hermes-chat.yaml
+++ b/backlog/02_stories_and_tasks.hermes-chat.yaml
@@ -910,3 +910,105 @@ stories:
           - Execute `bunx vitest run --silent='passed-only' 'tests/security/plugins/*'` alongside fuzz regression jobs and schema validation CLI.
         documentation:
           - Append security validation checklist and evidence storage process to `docs/plugins/catalog.md` and compliance runbooks.
+
+  - id: STORY-HC-120
+    epic_id: EPIC-HC-012
+    title: Ship enterprise onboarding wizard with ingestion health and governed agent templates
+    priority: P0
+    description: >-
+      Launch an enterprise-ready onboarding journey that automates workspace provisioning, orchestrates
+      ingestion health guardrails, and surfaces curated agent templates with governance context, ensuring
+      customers experience a resilient, automation-first setup from day zero.
+    # Context: Epic mandates zero-touch automation for onboarding, ingestion stability, and governed templates.
+    acceptance_criteria:
+      - >-
+        Multi-step onboarding wizard in `apps/web/app/(dashboard)/onboarding/` supports autosave/resume,
+        audit-friendly event logging, and surfaces automation hooks for provisioning providers, rate limits,
+        and agent scaffolds without requiring manual ops tickets.
+      - >-
+        Ingestion health scoring pipeline exposes ACL-aware diagnostics, remediation playbooks, and
+        streaming status cards within `apps/web/app/(dashboard)/knowledge/`, backed by `apps/services/ingestion-health/`
+        APIs capable of simulating large-document loads and tiered throttling policies.
+      - >-
+        Enterprise agent template library in `packages/agents/templates/` publishes governance notes, version metadata,
+        and admin controls surfaced within the dashboard, with automated verification preventing drift from approved baselines.
+      - >-
+        Idempotent automation jobs provision providers, enforce rate limit policies, and instantiate governed agent templates
+        when triggered by wizard completion events, with observable retries and rollback semantics.
+    testing:
+      - >-
+        Add wizard e2e resilience coverage (`tests/e2e/onboarding_wizard.resilience.spec.ts`) exercising autosave,
+        resume, and automation-trigger scenarios under flaky network simulations.
+      - >-
+        Implement ingestion large-document simulation suites leveraging `apps/services/ingestion-health/` load test harnesses
+        to validate scoring, ACL, and throttling flows before release.
+      - >-
+        Author snapshot/unit tests for enterprise agent templates ensuring governance metadata, schema integrity,
+        and admin surfacing toggles remain stable across releases.
+    documentation:
+      - >-
+        Expand `docs/usage/onboarding-enterprise.md` to cover wizard flow, ingestion health diagnostics,
+        automation expectations, and governed template operations with runbooks for SRE/CSM teams.
+    tasks:
+      - id: TASK-HC-120A
+        type: engineering
+        owner: onboarding-platform
+        description: >-
+          Build the multi-step onboarding experience in `apps/web/app/(dashboard)/onboarding/` using scalable state machines,
+          persistent autosave (e.g., secure draft API + optimistic UI), and automation webhooks that trigger idempotent
+          provisioning jobs; include copious inline documentation guiding future enhancements.
+        references:
+          - apps/web/app/(dashboard)/onboarding/
+          - apps/services/provisioning/
+          - tests/e2e/onboarding_wizard.resilience.spec.ts
+        automation:
+          - Implement reusable job orchestration (`apps/services/provisioning/jobs/`) that provisions providers, rate limits,
+            and baseline agents with retryable steps and centralized observability dashboards.
+        testing:
+          - Execute `bunx vitest run --silent='passed-only' 'tests/e2e/onboarding_wizard.resilience.spec.ts'` with network
+            chaos toggled, plus component/unit suites covering autosave reducers and state machines.
+        documentation:
+          - Update `docs/usage/onboarding-enterprise.md` wizard sections with flow diagrams, automation triggers,
+            and recovery SOPs; annotate code comments referencing doc anchors.
+
+      - id: TASK-HC-120B
+        type: engineering
+        owner: knowledge-insights
+        description: >-
+          Implement ingestion health scoring, ACL assignment, and validation tooling across
+          `apps/web/app/(dashboard)/knowledge/` and `apps/services/ingestion-health/`, instrumenting streaming telemetry,
+          large-document simulators, and remediation playbooks with extensive developer notes for maintainability.
+        references:
+          - apps/web/app/(dashboard)/knowledge/
+          - apps/services/ingestion-health/
+          - tests/services/ingestion-health/
+        automation:
+          - Create scheduled + on-demand ingestion diagnostics jobs that ingest synthetic corpora, auto-heal ACL drift,
+            and publish health signals to the wizard automation pipeline while enforcing idempotency.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'tests/services/ingestion-health/*'` and execute load simulations
+            via `bunx ts-node apps/services/ingestion-health/scripts/run-large-doc-sim.ts` against staging fixtures.
+        documentation:
+          - Document scoring formulas, ACL remediation SOP, and simulation harness usage in
+            `docs/usage/onboarding-enterprise.md` and supporting service READMEs.
+
+      - id: TASK-HC-120C
+        type: engineering
+        owner: agent-platform
+        description: >-
+          Publish enterprise agent templates with governance annotations in `packages/agents/templates/`, wire admin surfacing
+          into dashboard management panes, and ensure template lifecycle automation keeps production, staging, and sandbox
+          catalogs in sync with exhaustive inline commentary.
+        references:
+          - packages/agents/templates/
+          - apps/web/app/(dashboard)/admin/agents/
+          - tests/packages/agents/templates/
+        automation:
+          - Extend template publishing pipelines to sign, version, and distribute templates via centralized registries,
+            triggered by onboarding wizard completion and nightly drift detection jobs.
+        testing:
+          - Execute `bunx vitest run --silent='passed-only' 'tests/packages/agents/templates/*'` for snapshot/unit coverage
+            and validate admin surfacing via integration harness.
+        documentation:
+          - Update `docs/usage/onboarding-enterprise.md` with governance note conventions and admin controls,
+            and add CHANGELOG entries describing template lifecycle automation.


### PR DESCRIPTION
## Summary
- add STORY-HC-120 for EPIC-HC-012 covering onboarding wizard, ingestion health, and governed agent templates
- outline detailed tasks, automation requirements, and documentation/testing expectations for onboarding, ingestion health, and agent template delivery

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e31f81dc68832e956b5f7aa916fc28