### PR TITLE
Add EPIC-HC-010 plugin catalog hardening story

### DIFF
--- a/backlog/02_stories_and_tasks.hermes-chat.yaml
+++ b/backlog/02_stories_and_tasks.hermes-chat.yaml
@@ -1012,3 +1012,115 @@ stories:
         documentation:
           - Update `docs/usage/onboarding-enterprise.md` with governance note conventions and admin controls,
             and add CHANGELOG entries describing template lifecycle automation.
+
+  - id: STORY-HC-010
+    epic_id: EPIC-HC-010
+    title: Harden plugin catalog lifecycle with sandboxed execution guardrails
+    priority: P0
+    description: >-
+      Deliver an enterprise-grade plugin catalog experience that captures rich metadata, enforces
+      explicit permission prompts, governs egress allowlists, executes untrusted code inside the
+      WASM sandbox runtime, instruments analytics for adoption + drift detection, and provides a
+      remote kill-switch path for rapid containment.
+    # Context: Platform security review EPIC-HC-010 outlines compliance controls for pre-production
+    # plugin distribution and execution.
+    acceptance_criteria:
+      - >-
+        Admin catalog surfaces curated metadata (capabilities, data residency, security posture)
+        for every manifest sourced from registry sync, with inline developer notes and traceable
+        history.
+      - >-
+        Permission prompts render in the admin plugin console with granular scopes, rationale,
+        and automated approval workflows mapped to tenant RBAC policies.
+      - >-
+        Runtime enforces declarative egress allowlists per plugin manifest and blocks outbound
+        connections not represented in signed policy bundles.
+      - >-
+        WASM sandbox runtime isolates plugins with CPU/memory quotas, host capability shims, and
+        runtime attestation hooks emitting audit trails via telemetry package.
+      - >-
+        Kill-switch automation can remotely disable plugins across environments within 5 minutes,
+        logging actions, notifying stakeholders, and rolling back registry exposure.
+    testing:
+      - >-
+        Run sandbox escape fuzzing harness (`bunx vitest run --silent='passed-only'
+        'packages/plugins/runtime/tests/fuzz/*'`) for each merge and publish nightly reports.
+      - >-
+        Validate plugin manifest schema via `bun run lint:plugins-manifest` and capture golden
+        snapshots for admin UI + runtime integration tests in `tests/integration/plugins/catalog.spec.ts`.
+      - >-
+        Record integration snapshot artifacts (admin console + telemetry dashboards) in CI to
+        guard regressions across releases.
+    automation:
+      - >-
+        Schedule nightly WASM fuzzing GitHub Action with flaky-test quarantine + alerting to
+        security-oncall.
+      - >-
+        Extend registry sync workflow to sign manifests, regenerate SBOMs, and publish hash-indexed
+        catalogs to CDN with drift detection alerts.
+    documentation:
+      - >-
+        Update `docs/plugins/catalog.md` with developer notes covering metadata curation, prompt
+        copy decks, sandbox guardrails, telemetry signals, automation links, and kill-switch SOPs.
+    tasks:
+      - id: TASK-HC-010A
+        type: engineering
+        owner: platform-experience
+        description: >-
+          Extend `apps/web/app/(dashboard)/admin/plugins/` UI + server routes to display curated
+          metadata, render consent prompts with inline rationale, persist approval audit logs,
+          and centralize configuration toggles with exhaustive developer comments for maintainers.
+        references:
+          - apps/web/app/(dashboard)/admin/plugins/
+          - packages/plugins/catalog/
+          - tests/integration/plugins/
+        automation:
+          - Generate metadata JSON from manifest signatures during build via `scripts/plugins/catalog_sync.ts`
+            and wire GitHub Action to auto-populate admin caches.
+        testing:
+          - Execute `bunx vitest run --silent='passed-only' 'tests/integration/plugins/catalog.spec.ts'`
+            plus Playwright admin snapshots to ensure prompt flows and approval lifecycles function.
+        documentation:
+          - Add admin workflow diagrams + configuration matrix to `docs/plugins/catalog.md`, including
+            notes on minimizing manual approvals via policy inheritance.
+      - id: TASK-HC-010B
+        type: engineering
+        owner: runtime-security
+        description: >-
+          Fortify `packages/plugins/runtime/` WASM sandbox with resource quotas, deterministic
+          capability bridges, structured audit emitters, and integrated fuzz harnesses that feed
+          telemetry + failure corpora back into regression suites.
+        references:
+          - packages/plugins/runtime/
+          - packages/plugins/runtime/tests/
+          - scripts/fuzz/
+        automation:
+          - Add Temporal/Chronicle pipeline to seed nightly fuzz jobs, upload minimized crash cases,
+            and open auto-generated issues with stack traces + reproduction scripts.
+        testing:
+          - Run `bunx vitest run --silent='passed-only' 'packages/plugins/runtime/tests/**/*'` and
+            execute `scripts/fuzz/run_sandbox_escape.sh --ci` to validate harness integration.
+        documentation:
+          - Document sandbox quotas, host capability shims, and fuzz triage flow in
+            `docs/plugins/catalog.md` developer notes appendix.
+      - id: TASK-HC-010C
+        type: engineering
+        owner: observability-platform
+        description: >-
+          Instrument telemetry + kill-switch automation across `packages/plugins/telemetry/` and
+          GitHub Actions pipelines to publish signed manifests, stream audit signals, trigger
+          automated rollback, and expose dashboards minimizing manual operations.
+        references:
+          - packages/plugins/telemetry/
+          - .github/workflows/plugins-*.yml
+          - scripts/plugins/
+        automation:
+          - Wire kill-switch workflow to signed manifest publication, Slack/PagerDuty alerts, and
+            automated registry sync rollback with dry-run verification on schedule.
+        testing:
+          - Validate telemetry emitters via `bunx vitest run --silent='passed-only'
+            'packages/plugins/telemetry/tests/**/*'` and assert kill-switch CI workflow outcomes in
+            staging using workflow dispatch smoke tests.
+        documentation:
+          - Record telemetry schema, kill-switch runbook, and signed manifest distribution steps in
+            `docs/plugins/catalog.md` with explicit developer checklist + troubleshooting notes.


### PR DESCRIPTION
## Summary
- add STORY-HC-010 for EPIC-HC-010 to codify catalog metadata, sandboxing, telemetry, and kill-switch requirements
- break down tasks for admin console enhancements, runtime hardening, and telemetry automation with testing, automation, and documentation expectations

## Testing
- not run (backlog-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3255928ec832ea7097e0aacba0a9c